### PR TITLE
Switch database to postgres and run in docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+setup:
+	docker-compose up -d
+
+create-db: setup
+	docker exec defend-data-capture_db_1 psql -h localhost -U postgres -c "CREATE DATABASE defend WITH OWNER postgres ENCODING 'UTF8';"
+
+drop-db: setup
+	docker exec defend-data-capture_db_1 psql -h localhost -U postgres -c "DROP DATABASE defend"
+
+tests: setup
+	pytest api

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 A React and DRF app focused on collecting data about the UK's most valuable supply chains. This app is primarily a form in which other government departments can submit updates and provide information about the supply chains they manage. 
 
+## Running the API and its tests
+
+The project uses a `Makefile` to make running commands easier. `make` commands need to be run at the same directory level as the Makefile.
+
+To run the API:
+- If you haven't yet created a local database, run `make create-db`
+- If you have already created a local db, run `make setup` or `docker-compose up` to bring up the database
+- cd into the `/api` folder and run `python manage.py run server`
+
+To run API tests:
+- Run `make tests`
 
 ## Adding Black pre-commit hook
 

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -81,9 +81,8 @@ REST_FRAMEWORK = {
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    }
+        **env.db("DATABASE_URL"),
+    },
 }
 
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -19,6 +19,7 @@ packaging==20.9
 pathspec==0.8.1
 pluggy==0.13.1
 pre-commit==2.10.0
+psycopg2-binary==2.8.6
 py==1.10.0
 pyparsing==2.4.7
 pytest==6.2.2

--- a/api/sample.env
+++ b/api/sample.env
@@ -1,2 +1,2 @@
-
 DJANGO_SECRET_KEY=supersecretkey
+DATABASE_URL=postgres://postgres:password@localhost:5432/defend

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  db:
+    image: postgres:12
+    environment:
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5432:5432"


### PR DESCRIPTION
This PR sets the default database for the API as a postgres db and allows it to be run in docker. It also includes:

- a makefile with commands to create and drop the db in docker
- a db url in the sample.env
