### PR TITLE
Add supply chain end point

### DIFF
--- a/api/api/supply_chain_update/serializers.py
+++ b/api/api/supply_chain_update/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from api.supply_chain_update.models import StrategicAction
+from api.supply_chain_update.models import StrategicAction, SupplyChain
 
 
 class StrategicActionSerializer(serializers.ModelSerializer):
@@ -13,5 +13,20 @@ class StrategicActionSerializer(serializers.ModelSerializer):
             "description",
             "is_archived",
             "supply_chain",
+        ]
+        depth = 1
+
+
+class SupplyChainSerializer(serializers.ModelSerializer):
+    strategic_action_count = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = SupplyChain
+        fields = [
+            "id",
+            "name",
+            "last_submission_date",
+            "gov_department",
+            "strategic_action_count",
         ]
         depth = 1

--- a/api/api/supply_chain_update/test/test_views.py
+++ b/api/api/supply_chain_update/test/test_views.py
@@ -3,20 +3,27 @@ import pytest
 from django.urls import reverse
 from rest_framework.test import APIClient
 
-from api.supply_chain_update.models import StrategicAction
+from api.supply_chain_update.models import StrategicAction, SupplyChain
 from api.supply_chain_update.test.factories import (
     StrategicActionFactory,
     SupplyChainFactory,
 )
+from api.accounts.test.factories import GovDepartmentFactory
 
 
-@pytest.mark.django_db()
-def test_fails_if_unauthenticated():
+@pytest.mark.parametrize(
+    "url_name",
+    (
+        ("supply-chain-list"),
+        ("strategic-action-list"),
+    ),
+)
+def test_fails_if_unauthenticated(url_name):
     """
     Test that a 401 is returned if a request is made to the
-    '/strategic-action' endpoint from an unauthenticated user.
+     endpoints from an unauthenticated user.
     """
-    url = reverse("strategic-action-list")
+    url = reverse(url_name)
     client = APIClient()
     response = client.get(
         url,
@@ -47,7 +54,7 @@ def test_get_all_strategic_actions_from_a_given_supply_chain(
     test_client_with_token,
 ):
     """
-    Test that when a supply chain id is given in query paramters,
+    Test that when a supply chain id is given in query parameters,
     the '/strategic-action' endpoint returns a list of strategic actions
     related to that supply chain.
     """
@@ -56,9 +63,7 @@ def test_get_all_strategic_actions_from_a_given_supply_chain(
     # Create additional strategic action not linked to this supply chain
     StrategicActionFactory()
     client = test_client_with_token
-    response = client.get(
-        "/strategic-actions/", {"supply_chain_id": supply_chain.id}
-    )
+    response = client.get("/strategic-actions/", {"supply_chain_id": supply_chain.id})
     assert response.status_code == 200
     assert len(response.data) == 1
     assert response.data[0]["id"] == str(strategic_action.id)
@@ -74,3 +79,54 @@ def test_all_strategic_actions_returned_if_query_param_empty(
     response = client.get("/strategic-actions/", {"supply_chain_id": ""})
     assert response.status_code == 200
     assert len(response.data) == num_actions
+
+
+@pytest.mark.django_db()
+def test_get_all_supply_chains(
+    test_client_with_token,
+):
+    """
+    Test that all supply chain objects are returned when an
+    authorised request is made to the '/supply-chain' endpoint.
+    """
+    supply_chains = SupplyChainFactory.create_batch(4)
+    num_chains = SupplyChain.objects.count()
+    client = test_client_with_token
+    url = reverse("supply-chain-list")
+    response = client.get(url)
+    assert response.status_code == 200
+    assert len(response.data) == num_chains
+    assert response.data[0]["id"] == str(supply_chains[0].id)
+
+
+@pytest.mark.django_db()
+def test_get_all_supply_chain_from_a_given_government_department(
+    test_client_with_token,
+):
+    """
+    Test that when a government department id is given in query parameters,
+    the '/supply-chain' endpoint returns a list of supply chains
+    related to that government department.
+    """
+    gov_department = GovDepartmentFactory()
+    supply_chain = SupplyChainFactory(gov_department=gov_department)
+    # Create additional supply chain that is not linked to this gov department
+    SupplyChainFactory()
+    client = test_client_with_token
+    response = client.get("/supply-chains/", {"gov_department_id": gov_department.id})
+
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]["id"] == str(supply_chain.id)
+
+
+@pytest.mark.django_db()
+def test_all_supply_chains_returned_if_query_param_empty(
+    test_client_with_token,
+):
+    SupplyChainFactory.create_batch(5)
+    num_chains = SupplyChain.objects.count()
+    client = test_client_with_token
+    response = client.get("/supply-chains/", {"supply_chain_id": ""})
+    assert response.status_code == 200
+    assert len(response.data) == num_chains

--- a/api/api/supply_chain_update/views.py
+++ b/api/api/supply_chain_update/views.py
@@ -1,8 +1,12 @@
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
+from django.db.models import Count
 
-from api.supply_chain_update.models import StrategicAction
-from api.supply_chain_update.serializers import StrategicActionSerializer
+from api.supply_chain_update.models import StrategicAction, SupplyChain
+from api.supply_chain_update.serializers import (
+    StrategicActionSerializer,
+    SupplyChainSerializer,
+)
 
 
 class StrategicActionViewset(viewsets.ModelViewSet):
@@ -20,4 +24,24 @@ class StrategicActionViewset(viewsets.ModelViewSet):
         )
         if supply_chain_id:
             queryset = queryset.filter(supply_chain__id=supply_chain_id)
+        return queryset
+
+
+class SupplyChainViewset(viewsets.ModelViewSet):
+    """
+    A viewset that returns Supply Chain objects
+    """
+
+    serializer_class = SupplyChainSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        queryset = SupplyChain.objects.all()
+        gov_department_id = self.request.query_params.get("gov_department_id")
+
+        if gov_department_id:
+            queryset = queryset.filter(gov_department__id=gov_department_id)
+            queryset = queryset.annotate(
+                strategic_action_count=Count("strategic_actions")
+            )
         return queryset

--- a/api/api/urls.py
+++ b/api/api/urls.py
@@ -2,14 +2,15 @@ from django.contrib import admin
 from django.urls import path, include
 from rest_framework import routers
 
-from api.accounts import views as accounts_views
-from api.supply_chain_update.views import StrategicActionViewset
+from api.accounts.views import UserViewSet
+from api.supply_chain_update.views import StrategicActionViewset, SupplyChainViewset
 
 router = routers.DefaultRouter()
-router.register(r"users", accounts_views.UserViewSet, basename="user")
+router.register(r"users", UserViewSet, basename="user")
 router.register(
     r"strategic-actions", StrategicActionViewset, basename="strategic-action"
 )
+router.register(r"supply-chains", SupplyChainViewset, basename="supply-chain")
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
This PR adds an endpoint with CRUD operations on the SupplyChain model. It also includes a filter on the view which allows a `gov_department_id` parameter to be passed to the endpoint (/supply-chains?gov_department_id=XXX) which will just return supply chains linked to that government department. An annotation has also been added to return the number of strategic actions linked to a supply chain, on each returned supply chain object.

The tests included check the basics of the route. Please let me know if you have any suggestions for how I can make this code better though! 🎉 
