### PR TITLE
Add filter to the strategic-actions endpoint to allow filtering by is_archived

### DIFF
--- a/api/api/supply_chain_update/views.py
+++ b/api/api/supply_chain_update/views.py
@@ -22,8 +22,13 @@ class StrategicActionViewset(viewsets.ModelViewSet):
         supply_chain_id = self.request.query_params.get(
             "supply_chain_id",
         )
+        is_archived = self.request.query_params.get(
+            "is_archived",
+        )
         if supply_chain_id:
             queryset = queryset.filter(supply_chain__id=supply_chain_id)
+        if is_archived:
+            queryset = queryset.filter(is_archived=is_archived.capitalize())
         return queryset
 
 


### PR DESCRIPTION
This PR adds a filter to the `/strategic-actions` endpoint, allowing additional filtering for archived/unarchived actions. It also includes a filter on the view which allows a supply_chain_id query parameter to be passed to the endpoint (/strategic-actions?supply_chain_id=XXX&is_archived=true/false) which will just return strategic actions linked to that supply chain,  if they are archived or not.

Tests have been added or amended to cater for this filtering but additional test suggestions are very welcome 😄 