### PR TITLE
Add endpoint for strategic action updates

### DIFF
--- a/api/api/supply_chain_update/serializers.py
+++ b/api/api/supply_chain_update/serializers.py
@@ -1,6 +1,10 @@
 from rest_framework import serializers
 
-from api.supply_chain_update.models import StrategicAction, SupplyChain
+from api.supply_chain_update.models import (
+    StrategicAction,
+    StrategicActionUpdate,
+    SupplyChain,
+)
 
 
 class StrategicActionSerializer(serializers.ModelSerializer):
@@ -30,3 +34,19 @@ class SupplyChainSerializer(serializers.ModelSerializer):
             "strategic_action_count",
         ]
         depth = 1
+
+
+class StrategicActionUpdateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = StrategicActionUpdate
+        fields = [
+            "id",
+            "is_draft",
+            "submission_date",
+            "content",
+            "implementation_rag_rating",
+            "reason_for_delays",
+            "user",
+            "strategic_action",
+            "supply_chain",
+        ]

--- a/api/api/supply_chain_update/serializers.py
+++ b/api/api/supply_chain_update/serializers.py
@@ -41,7 +41,7 @@ class StrategicActionUpdateSerializer(serializers.ModelSerializer):
         model = StrategicActionUpdate
         fields = [
             "id",
-            "is_draft",
+            "status",
             "submission_date",
             "content",
             "implementation_rag_rating",

--- a/api/api/supply_chain_update/test/factories.py
+++ b/api/api/supply_chain_update/test/factories.py
@@ -1,6 +1,6 @@
 import factory
 
-from api.accounts.test.factories import GovDepartmentFactory
+from api.accounts.test.factories import GovDepartmentFactory, UserFactory
 
 
 class SupplyChainFactory(factory.django.DjangoModelFactory):
@@ -21,3 +21,15 @@ class StrategicActionFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = "supply_chain_update.StrategicAction"
+
+
+class StrategicActionUpdateFactory(factory.django.DjangoModelFactory):
+    submission_date = factory.Faker("date_object")
+    content = factory.Faker("sentence")
+    implementation_rag_rating = "Green"
+    user = factory.SubFactory(UserFactory)
+    strategic_action = factory.SubFactory(StrategicActionFactory)
+    supply_chain = factory.SubFactory(SupplyChainFactory)
+
+    class Meta:
+        model = "supply_chain_update.StrategicActionUpdate"

--- a/api/api/supply_chain_update/test/test_views.py
+++ b/api/api/supply_chain_update/test/test_views.py
@@ -200,3 +200,39 @@ def test_get_all_strategic_action_updates(
     assert response.status_code == 200
     assert len(response.data) == num_updates
     assert response.data[0]["id"] == str(updates[0].id)
+
+
+@pytest.mark.django_db()
+def test_filter_updates_by_strategic_action(
+    test_client_with_token,
+):
+    """
+    Test that when a strategic action id is given in query paramters,
+    the '/strategic-action-updates' endpoint returns a list of updates
+    related to that strategic action.
+    """
+    strategic_action = StrategicActionFactory()
+    strategic_action_update = StrategicActionUpdateFactory(
+        strategic_action=strategic_action,
+    )
+    # Create additional updates not linked to this strategic action
+    StrategicActionUpdateFactory.create_batch(5)
+    client = test_client_with_token
+    response = client.get(
+        "/strategic-action-updates/", {"strategic_action_id": strategic_action.id}
+    )
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]["id"] == str(strategic_action_update.id)
+
+
+@pytest.mark.django_db()
+def test_all_updates_returned_if_strat_action_id_empty(
+    test_client_with_token,
+):
+    StrategicActionUpdateFactory.create_batch(5)
+    num_updates = StrategicActionUpdate.objects.count()
+    client = test_client_with_token
+    response = client.get("/strategic-action-updates/", {"strategic_action_id": ""})
+    assert response.status_code == 200
+    assert len(response.data) == num_updates

--- a/api/api/supply_chain_update/test/test_views.py
+++ b/api/api/supply_chain_update/test/test_views.py
@@ -3,9 +3,14 @@ import pytest
 from django.urls import reverse
 from rest_framework.test import APIClient
 
-from api.supply_chain_update.models import StrategicAction, SupplyChain
+from api.supply_chain_update.models import (
+    StrategicAction,
+    StrategicActionUpdate,
+    SupplyChain,
+)
 from api.supply_chain_update.test.factories import (
     StrategicActionFactory,
+    StrategicActionUpdateFactory,
     SupplyChainFactory,
 )
 from api.accounts.test.factories import GovDepartmentFactory
@@ -14,8 +19,9 @@ from api.accounts.test.factories import GovDepartmentFactory
 @pytest.mark.parametrize(
     "url_name",
     (
-        ("supply-chain-list"),
-        ("strategic-action-list"),
+        "supply-chain-list",
+        "strategic-action-list",
+        "strategic-action-update-list",
     ),
 )
 def test_fails_if_unauthenticated(url_name):
@@ -176,3 +182,21 @@ def test_all_supply_chains_returned_if_query_param_empty(
     response = client.get("/supply-chains/", {"supply_chain_id": ""})
     assert response.status_code == 200
     assert len(response.data) == num_chains
+
+
+@pytest.mark.django_db()
+def test_get_all_strategic_action_updates(
+    test_client_with_token,
+):
+    """
+    Test that all strategic action update objects are returned when an
+    authorised request is made to the '/strategic-action-update' endpoint.
+    """
+    updates = StrategicActionUpdateFactory.create_batch(5)
+    num_updates = StrategicActionUpdate.objects.count()
+    client = test_client_with_token
+    url = reverse("strategic-action-update-list")
+    response = client.get(url)
+    assert response.status_code == 200
+    assert len(response.data) == num_updates
+    assert response.data[0]["id"] == str(updates[0].id)

--- a/api/api/supply_chain_update/views.py
+++ b/api/api/supply_chain_update/views.py
@@ -1,3 +1,5 @@
+from distutils.util import strtobool
+
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 from django.db.models import Count
@@ -71,4 +73,12 @@ class StrategicActionUpdateViewset(viewsets.ModelViewSet):
         strategic_action_id = self.request.query_params.get("strategic_action_id")
         if strategic_action_id:
             queryset = queryset.filter(strategic_action__id=strategic_action_id)
+
+        is_submitted = self.request.query_params.get("is_submitted")
+        if is_submitted:
+            is_submitted = strtobool(is_submitted)
+            if is_submitted:
+                queryset = queryset.filter(status="submitted")
+            else:
+                queryset = queryset.exclude(status="submitted")
         return queryset

--- a/api/api/supply_chain_update/views.py
+++ b/api/api/supply_chain_update/views.py
@@ -67,7 +67,8 @@ class StrategicActionUpdateViewset(viewsets.ModelViewSet):
 
     def get_queryset(self):
         queryset = StrategicActionUpdate.objects.all()
-        is_draft = self.request.query_params.get("is_draft")
-        if is_draft:
-            queryset = queryset.filter(is_draft=True)
+
+        strategic_action_id = self.request.query_params.get("strategic_action_id")
+        if strategic_action_id:
+            queryset = queryset.filter(strategic_action__id=strategic_action_id)
         return queryset

--- a/api/api/supply_chain_update/views.py
+++ b/api/api/supply_chain_update/views.py
@@ -2,9 +2,14 @@ from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 from django.db.models import Count
 
-from api.supply_chain_update.models import StrategicAction, SupplyChain
+from api.supply_chain_update.models import (
+    StrategicAction,
+    StrategicActionUpdate,
+    SupplyChain,
+)
 from api.supply_chain_update.serializers import (
     StrategicActionSerializer,
+    StrategicActionUpdateSerializer,
     SupplyChainSerializer,
 )
 
@@ -49,4 +54,20 @@ class SupplyChainViewset(viewsets.ModelViewSet):
             queryset = queryset.annotate(
                 strategic_action_count=Count("strategic_actions")
             )
+        return queryset
+
+
+class StrategicActionUpdateViewset(viewsets.ModelViewSet):
+    """
+    A viewset that returns Strategic Action update objects.
+    """
+
+    serializer_class = StrategicActionUpdateSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        queryset = StrategicActionUpdate.objects.all()
+        is_draft = self.request.query_params.get("is_draft")
+        if is_draft:
+            queryset = queryset.filter(is_draft=True)
         return queryset

--- a/api/api/urls.py
+++ b/api/api/urls.py
@@ -3,7 +3,11 @@ from django.urls import path, include
 from rest_framework import routers
 
 from api.accounts.views import UserViewSet
-from api.supply_chain_update.views import StrategicActionViewset, SupplyChainViewset
+from api.supply_chain_update.views import (
+    StrategicActionViewset,
+    StrategicActionUpdateViewset,
+    SupplyChainViewset,
+)
 
 router = routers.DefaultRouter()
 router.register(r"users", UserViewSet, basename="user")
@@ -11,6 +15,11 @@ router.register(
     r"strategic-actions", StrategicActionViewset, basename="strategic-action"
 )
 router.register(r"supply-chains", SupplyChainViewset, basename="supply-chain")
+router.register(
+    r"strategic-action-updates",
+    StrategicActionUpdateViewset,
+    basename="strategic-action-update",
+)
 
 urlpatterns = [
     path("admin/", admin.site.urls),

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -4,6 +4,8 @@ from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 
 from api.accounts.test.factories import UserFactory
+from api.supply_chain_update.models import StrategicActionUpdate
+from api.supply_chain_update.test.factories import StrategicActionUpdateFactory
 
 
 @pytest.fixture
@@ -21,3 +23,24 @@ def test_client_with_token(test_user):
     client = APIClient()
     client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
     yield client
+
+
+@pytest.fixture
+def test_in_progress_strategic_action_update():
+    update = StrategicActionUpdateFactory()
+    update.save()
+    yield update
+
+
+@pytest.fixture
+def test_completed_strategic_action_update():
+    update = StrategicActionUpdateFactory(status=StrategicActionUpdate.Status.COMPLETED)
+    update.save()
+    yield update
+
+
+@pytest.fixture
+def test_submitted_strategic_action_update():
+    update = StrategicActionUpdateFactory(status=StrategicActionUpdate.Status.SUBMITTED)
+    update.save()
+    yield update


### PR DESCRIPTION
This PR adds an API endpoint `strategic-action-updates` to perform CRUD operations on the `StrategicActionUpdate` model. It allows two filters which can be applied to get requests:

- Filtering by `strategic_action_id`, which will get all updates related to a strategic action
- Filtering by `is_submitted`, which when true will only return updates with a status of `submitted`, and when false will return updates with a status of either `in_progress` or `completed`. This distinction is to allow users to update non-submitted updates. 