### PR TITLE
Update Django dependency to fix security issue

### DIFF
--- a/defend_data_capture/requirements.txt
+++ b/defend_data_capture/requirements.txt
@@ -7,7 +7,7 @@ cfgv==3.2.0
 chardet==4.0.0
 click==7.1.2
 distlib==0.3.1
-Django==3.1.5
+django>=3.1.6
 django-environ==0.4.5
 django-staff-sso-client==3.1.0
 django-reversion==3.0.9


### PR DESCRIPTION
This PR updates the Django dependency, as advised by a security warning from Github. 

Here's the link to the security update : https://www.djangoproject.com/weblog/2021/feb/01/security-releases/