### PR TITLE
#21: Using docker-compose to refer container instance within Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@ setup:
 	docker-compose up -d
 
 setup-db: setup
-	docker exec defend-data-capture_db_1 psql -h localhost -U postgres -c "CREATE DATABASE defend WITH OWNER postgres ENCODING 'UTF8';"
+	docker-compose exec db psql -h localhost -U postgres -c "CREATE DATABASE defend WITH OWNER postgres ENCODING 'UTF8';"
 	python defend_data_capture/manage.py migrate
 	python defend_data_capture/manage.py createinitialrevisions
 
 drop-db: setup
-	docker exec defend-data-capture_db_1 psql -h localhost -U postgres -c "DROP DATABASE defend"
+	docker-compose exec db psql -h localhost -U postgres -c "DROP DATABASE defend"
 
 tests: setup
 	pytest defend_data_capture


### PR DESCRIPTION
**Description**

Fix Makefile errors on some of the targets, refer #21 

**Changes**

- Use _docker-compose_ to reference a container instead of _docker_. Docker commands require name of the container as an argument which is not a constant

