### PR TITLE
Update urllib3 package due to security vulnerability

### DIFF
--- a/defend_data_capture/requirements.txt
+++ b/defend_data_capture/requirements.txt
@@ -43,5 +43,5 @@ text-unidecode==1.3
 toml==0.10.2
 typed-ast==1.4.2
 typing-extensions==3.7.4.3
-urllib3==1.26.3
+urllib3==1.26.4
 virtualenv==20.4.0


### PR DESCRIPTION
This PR updates the dependency `urllib` as Dependabot has flagged the previous version as having a security vulnerability ([here](https://github.com/uktrade/defend-data-capture/security/dependabot)).