### PR TITLE
Add github action for running unit tests

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,0 +1,31 @@
+name: run-tests
+on: [pull_request]
+jobs:
+  run-all-tests:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: postgres://postgres:password@localhost:5432/defend
+      OAUTHLIB_INSECURE_TRANSPORT: 1
+      RUNNING_LOCALLY: 0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: Install python packages
+        run: pip install -r defend_data_capture/requirements.txt
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Install node modules
+        run: npm install
+      - name: Run webpack
+        run: nohup npm run dev &
+      - name: Bring up db container
+        run: docker-compose -f docker-compose.yaml up -d
+      - name: Run unit tests
+        run: pytest defend_data_capture
+      - name: Run functional tests
+        run: bash run_functional_tests.sh

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ backend.pid
 # Folders and file auto-generated when cypress is run
 cypress/videos/
 cypress/screenshots/
-cypress.json

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 setup:
-	docker-compose up -d
+	docker-compose -f docker-compose.yaml up -d
 
 setup-db: setup
 	python defend_data_capture/manage.py migrate

--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,3 @@
+{
+    "videoUploadOnPasses": false
+}

--- a/defend_data_capture/defend_data_capture/settings.py
+++ b/defend_data_capture/defend_data_capture/settings.py
@@ -16,7 +16,7 @@ environ.Env.read_env(env_file=os.path.join(BASE_DIR, ".env"))
 
 env = environ.Env()
 
-SECRET_KEY = env("DJANGO_SECRET_KEY")
+SECRET_KEY = env("DJANGO_SECRET_KEY", default="secret-key")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -118,9 +118,9 @@ AUTHENTICATION_BACKENDS = [
 LOGIN_URL = reverse_lazy("authbroker_client:login")
 LOGIN_REDIRECT_URL = reverse_lazy("index")
 AUTH_USER_MODEL = "accounts.User"
-AUTHBROKER_URL = env("AUTHBROKER_URL")
-AUTHBROKER_CLIENT_ID = env("AUTHBROKER_CLIENT_ID")
-AUTHBROKER_CLIENT_SECRET = env("AUTHBROKER_CLIENT_SECRET")
+AUTHBROKER_URL = env("AUTHBROKER_URL", default="")
+AUTHBROKER_CLIENT_ID = env("AUTHBROKER_CLIENT_ID", default="")
+AUTHBROKER_CLIENT_SECRET = env("AUTHBROKER_CLIENT_SECRET", default="")
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.1/topics/i18n/

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+running_locally=${RUNNING_LOCALLY:-true}
+
 # Bring up the db and mock-sso docker containers
 docker-compose -f docker-compose.yaml -f docker-compose.override.yaml up -d
 
@@ -14,8 +16,9 @@ python defend_data_capture/manage.py testserver \
     & echo $! > backend.pid \
     & (sleep 5 && npx cypress run --headless --browser chrome --config-file false)
 
-# Kill the application using the pid previously saved
-kill $(cat backend.pid)
-
-# Drop the test database
-docker-compose exec db psql -h localhost -U postgres -c "DROP DATABASE IF EXISTS test_defend"
+if [ "$running_locally" == true ]; then
+    # Kill the application using the pid previously saved
+    kill $(cat backend.pid)
+    # Drop the test database
+    docker-compose exec db psql -h localhost -U postgres -c "DROP DATABASE IF EXISTS test_defend"
+fi

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -14,7 +14,7 @@ python defend_data_capture/manage.py testserver \
     cypress/fixtures/govDepartment.json cypress/fixtures/user.json \
     cypress/fixtures/supplyChains.json cypress/fixtures/strategicActions.json \
     & echo $! > backend.pid \
-    & (sleep 5 && npx cypress run --headless --browser chrome --config-file false)
+    & (sleep 5 && npx cypress run --headless --browser chrome)
 
 if [ "$running_locally" == true ]; then
     # Kill the application using the pid previously saved


### PR DESCRIPTION
### Purpose of PR
This PR adds a github action to run both the unit and functional tests against all pull requests.

It also includes some tweaks to existing commands to make them run more efficiently (and therefore the action quicker) including:
- Not saving the video which cypress records of the functional tests if they pass
- Only killing the pid process and dropping the test database table when running the functional tests locally
- Only bringing up the db container in docker apart from in when running the functional tests (which also need the mock-sso container)

I have also provided defaults for the settings which take their values from environment variables, which avoids the need to set them as blank values for running the unit tests, as they are not needed for these tests.

### To consider
I had planned to have two separate jobs - one for unit and one for functional tests - to make it clearer which was failing in the checks. However webpack is needed to run the unit tests, as the webpack-loader `load_assets` function is called when the frontend urls are called and fails without a `webpack-stats.json` file. So to avoid installing all npm and python packages twice, I have included running both tests in the same job. 

If you have any suggestions for how to split into two jobs please let me know! 😄 

### To test
Click on the `details` link on the check in this PR to see the tests being run in action (no pun intended 😉 ).

![Screenshot 2021-04-14 at 15 23 44](https://user-images.githubusercontent.com/22460823/114726552-68158380-9d35-11eb-8c11-efbfa9fdb00a.png)
