### PR TITLE
Add strategic action summary page

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,4 +2,4 @@
     "baseUrl": "http://localhost:8001",
     "defaultCommandTimeout": 2000,
     "videoUploadOnPasses": false
-  }
+}

--- a/cypress/fixtures/strategicActions.json
+++ b/cypress/fixtures/strategicActions.json
@@ -1,182 +1,322 @@
 [
-{
-  "model": "supply_chains.strategicaction",
-  "pk": "18a8b9c3-f85c-49f6-8db0-e5194743b9c6",
-  "fields": {
-    "name": "SA 01",
-    "start_date": "2021-04-06",
-    "description": "Sample 01 asdfdsf adfasdf adsfasdf asdfasdf asdfasdfas asdfasdf adskfjh faksdfh  asdfsdf asdfasdf ",
-    "impact": "None",
-    "category": "Create",
-    "geographic_scope": "uk-wide",
-    "supporting_organisations": "HMT",
-    "is_ongoing": false,
-    "target_completion_date": null,
-    "is_archived": false,
-    "supply_chain": "107f8ea4-aec0-4bea-b68d-a65720c97022",
-    "slug": "sa-01"
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "18a8b9c3-f85c-49f6-8db0-e5194743b9c6",
+    "fields": {
+      "name": "SA 01",
+      "start_date": "2021-04-06",
+      "description": "Sample 01 asdfdsf adfasdf adsfasdf asdfasdf asdfasdfas asdfasdf adskfjh faksdfh  asdfsdf asdfasdf ",
+      "impact": "None",
+      "category": "Create",
+      "geographic_scope": "uk-wide",
+      "supporting_organisations": "HMT",
+      "is_ongoing": false,
+      "target_completion_date": null,
+      "is_archived": false,
+      "specific_related_products": "",
+      "other_dependencies": "",
+      "supply_chain": "107f8ea4-aec0-4bea-b68d-a65720c97022",
+      "slug": "sa-01"
+    }
+  },
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "35f39db6-fa71-4f82-b86a-238e8398b753",
+    "fields": {
+      "name": "SA 00",
+      "start_date": "2021-04-06",
+      "description": "Sample 00 asdfdsf adfasdf adsfasdf asdfasdf asdfasdfas asdfasdf asds dfdfd fgfgg rtrtr ggfg",
+      "impact": "None",
+      "category": "Create",
+      "geographic_scope": "uk-wide",
+      "supporting_organisations": "HMT",
+      "is_ongoing": false,
+      "target_completion_date": null,
+      "is_archived": false,
+      "specific_related_products": "",
+      "other_dependencies": "",
+      "supply_chain": "107f8ea4-aec0-4bea-b68d-a65720c97022",
+      "slug": "sa-00"
+    }
+  },
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "4fa80be8-3edc-40be-8989-9b5a9f1e0e34",
+    "fields": {
+      "name": "SA 05",
+      "start_date": "2009-03-01",
+      "description": "",
+      "impact": "",
+      "category": "",
+      "geographic_scope": "",
+      "supporting_organisations": "",
+      "is_ongoing": false,
+      "target_completion_date": null,
+      "is_archived": false,
+      "specific_related_products": "",
+      "other_dependencies": "",
+      "supply_chain": "107f8ea4-aec0-4bea-b68d-a65720c97022",
+      "slug": "sa-05"
+    }
+  },
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "6becafd3-d19e-4118-999a-b069debcac54",
+    "fields": {
+      "name": "SA 04",
+      "start_date": "2009-03-01",
+      "description": "",
+      "impact": "",
+      "category": "",
+      "geographic_scope": "",
+      "supporting_organisations": "",
+      "is_ongoing": false,
+      "target_completion_date": null,
+      "is_archived": false,
+      "specific_related_products": "",
+      "other_dependencies": "",
+      "supply_chain": "107f8ea4-aec0-4bea-b68d-a65720c97022",
+      "slug": "sa-04"
+    }
+  },
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "a38838d0-362a-411c-a7c8-65db9981d0bf",
+    "fields": {
+      "name": "SA 02",
+      "start_date": "2009-03-01",
+      "description": "",
+      "impact": "",
+      "category": "",
+      "geographic_scope": "",
+      "supporting_organisations": "",
+      "is_ongoing": false,
+      "target_completion_date": null,
+      "is_archived": false,
+      "specific_related_products": "",
+      "other_dependencies": "",
+      "supply_chain": "107f8ea4-aec0-4bea-b68d-a65720c97022",
+      "slug": "sa-02"
+    }
+  },
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "e3ff7167-9298-45ed-bcca-7c8a923be491",
+    "fields": {
+      "name": "Strategic action 1",
+      "start_date": "1982-03-07",
+      "description": "Cover than item risk difficult.",
+      "impact": "",
+      "category": "",
+      "geographic_scope": "",
+      "supporting_organisations": "",
+      "is_ongoing": false,
+      "target_completion_date": null,
+      "is_archived": false,
+      "specific_related_products": "",
+      "other_dependencies": "",
+      "supply_chain": "107f8ea4-aec0-4bea-b68d-a65720c97022",
+      "slug": "strategic-action-1"
+    }
+  },
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "eec5752e-55ac-4f3e-a96e-75825526b313",
+    "fields": {
+      "name": "Strategic action 2",
+      "start_date": "1984-08-20",
+      "description": "Stock marriage idea add expect visit director.",
+      "impact": "",
+      "category": "",
+      "geographic_scope": "",
+      "supporting_organisations": "",
+      "is_ongoing": false,
+      "target_completion_date": null,
+      "is_archived": false,
+      "specific_related_products": "",
+      "other_dependencies": "",
+      "supply_chain": "14201f69-2d95-4b4c-9523-b44c6c732a80",
+      "slug": "strategic-action-2"
+    }
+  },
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "f12777b8-c2f7-4f1e-ae52-acf79809b0b6",
+    "fields": {
+      "name": "SA 03",
+      "start_date": "2009-03-01",
+      "description": "",
+      "impact": "",
+      "category": "",
+      "geographic_scope": "",
+      "supporting_organisations": "",
+      "is_ongoing": false,
+      "target_completion_date": null,
+      "is_archived": false,
+      "specific_related_products": "",
+      "other_dependencies": "",
+      "supply_chain": "107f8ea4-aec0-4bea-b68d-a65720c97022",
+      "slug": "sa-03"
+    }
+  },
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "fa87e1d4-baaa-4317-89b6-fcade510b015",
+    "fields": {
+      "name": "SA 20",
+      "start_date": "2021-04-06",
+      "description": "Sample 20 asdfdsf adfasdf adsfasdf asdfasdf asdfasdfas asdfasdf",
+      "impact": "None",
+      "category": "Create",
+      "geographic_scope": "uk-wide",
+      "supporting_organisations": "HMT",
+      "is_ongoing": false,
+      "target_completion_date": null,
+      "is_archived": false,
+      "specific_related_products": "",
+      "other_dependencies": "",
+      "supply_chain": "14201f69-2d95-4b4c-9523-b44c6c732a80",
+      "slug": "sa-20"
+    }
+  },
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "fd317f3e-9ce0-4ed0-9a6a-baf7c6e65989",
+    "fields": {
+      "name": "Strategic action 0",
+      "start_date": "1978-03-23",
+      "description": "Garden together job.",
+      "impact": "",
+      "category": "",
+      "geographic_scope": "",
+      "supporting_organisations": "",
+      "is_ongoing": false,
+      "target_completion_date": null,
+      "is_archived": false,
+      "specific_related_products": "",
+      "other_dependencies": "",
+      "supply_chain": "e7e81077-399f-4004-a907-e0a2862a84de",
+      "slug": "strategic-action-0"
+    }
+  },
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "e4ff7167-9298-45ed-bcca-7c8a923be491",
+    "fields": {
+      "name": "Strategic action 1",
+      "start_date": "2019-11-14",
+      "description": "President run way so make standard. Player morning sure no director involve may. Visit contain unit. Throw lawyer idea protect amount lose computer.",
+      "impact": "Reveal protect assume challenge able buy. Want cell next finally himself security rather peace. Serve star eight wall decade man class main.",
+      "category": "diversify",
+      "geographic_scope": "england_only",
+      "supporting_organisations": "MOD",
+      "is_ongoing": false,
+      "target_completion_date": "2023-02-08",
+      "is_archived": false,
+      "specific_related_products": "Always discussion they brother worker. Represent so clear character least I. Door full add senior. Believe able help site machine whom. Property whose recent each director certain.",
+      "other_dependencies": "Along ground determine itself food. West executive over notice newspaper quite skin college. Technology company rule between.",
+      "supply_chain": "f6787b31-a016-4c9a-92a9-03be1b656cb4",
+      "slug": "strategic-action-1"
+    }
+  },
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "607990ca-91e2-4f2f-8dce-4eb0ac17bfd1",
+    "fields": {
+      "name": "Strategic action 2",
+      "start_date": "1982-03-07",
+      "description": "Cover than item risk difficult.",
+      "impact": "",
+      "category": "",
+      "geographic_scope": "",
+      "supporting_organisations": "",
+      "is_ongoing": false,
+      "target_completion_date": null,
+      "is_archived": false,
+      "specific_related_products": "",
+      "other_dependencies": "",
+      "supply_chain": "f6787b31-a016-4c9a-92a9-03be1b656cb4",
+      "slug": "strategic-action-2"
+    }
+  },
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "fe10c583-6a7b-4606-8d90-e7e870e1a63e",
+    "fields": {
+      "name": "Strategic action 3",
+      "start_date": "1982-03-07",
+      "description": "Cover than item risk difficult.",
+      "impact": "",
+      "category": "",
+      "geographic_scope": "",
+      "supporting_organisations": "",
+      "is_ongoing": false,
+      "target_completion_date": null,
+      "is_archived": false,
+      "specific_related_products": "",
+      "other_dependencies": "",
+      "supply_chain": "f6787b31-a016-4c9a-92a9-03be1b656cb4",
+      "slug": "strategic-action-3"
+    }
+  },
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "55b22a7f-65fa-48c5-82f2-7918214936c5",
+    "fields": {
+      "name": "Strategic action 4",
+      "start_date": "1982-03-07",
+      "description": "Cover than item risk difficult.",
+      "impact": "",
+      "category": "",
+      "geographic_scope": "",
+      "supporting_organisations": "",
+      "is_ongoing": false,
+      "target_completion_date": null,
+      "is_archived": false,
+      "specific_related_products": "",
+      "other_dependencies": "",
+      "supply_chain": "f6787b31-a016-4c9a-92a9-03be1b656cb4",
+      "slug": "strategic-action-4"
+    }
+  },
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "982bda67-4808-4231-b16b-c1f84c4ea110",
+    "fields": {
+      "name": "Strategic action 5",
+      "start_date": "1982-03-07",
+      "description": "Cover than item risk difficult.",
+      "impact": "",
+      "category": "",
+      "geographic_scope": "",
+      "supporting_organisations": "",
+      "is_ongoing": false,
+      "target_completion_date": null,
+      "is_archived": false,
+      "specific_related_products": "",
+      "other_dependencies": "",
+      "supply_chain": "f6787b31-a016-4c9a-92a9-03be1b656cb4",
+      "slug": "strategic-action-5"
+    }
+  },
+  {
+    "model": "supply_chains.strategicaction",
+    "pk": "0609cec6-6990-4bd5-a35a-fbf72aafcbb3",
+    "fields": {
+      "name": "Strategic action 6",
+      "start_date": "1982-03-07",
+      "description": "Cover than item risk difficult.",
+      "impact": "",
+      "category": "",
+      "geographic_scope": "",
+      "supporting_organisations": "",
+      "is_ongoing": false,
+      "target_completion_date": null,
+      "is_archived": false,
+      "specific_related_products": "",
+      "other_dependencies": "",
+      "supply_chain": "f6787b31-a016-4c9a-92a9-03be1b656cb4",
+      "slug": "strategic-action-6"
+    }
   }
-},
-{
-  "model": "supply_chains.strategicaction",
-  "pk": "35f39db6-fa71-4f82-b86a-238e8398b753",
-  "fields": {
-    "name": "SA 00",
-    "start_date": "2021-04-06",
-    "description": "Sample 00 asdfdsf adfasdf adsfasdf asdfasdf asdfasdfas asdfasdf asds dfdfd fgfgg rtrtr ggfg",
-    "impact": "None",
-    "category": "Create",
-    "geographic_scope": "uk-wide",
-    "supporting_organisations": "HMT",
-    "is_ongoing": false,
-    "target_completion_date": null,
-    "is_archived": false,
-    "supply_chain": "107f8ea4-aec0-4bea-b68d-a65720c97022",
-    "slug": "sa-00"
-  }
-},
-{
-  "model": "supply_chains.strategicaction",
-  "pk": "4fa80be8-3edc-40be-8989-9b5a9f1e0e34",
-  "fields": {
-    "name": "SA 05",
-    "start_date": "2009-03-01",
-    "description": "",
-    "impact": "",
-    "category": "",
-    "geographic_scope": "",
-    "supporting_organisations": "",
-    "is_ongoing": false,
-    "target_completion_date": null,
-    "is_archived": false,
-    "supply_chain": "107f8ea4-aec0-4bea-b68d-a65720c97022",
-    "slug": "sa-05"
-  }
-},
-{
-  "model": "supply_chains.strategicaction",
-  "pk": "6becafd3-d19e-4118-999a-b069debcac54",
-  "fields": {
-    "name": "SA 04",
-    "start_date": "2009-03-01",
-    "description": "",
-    "impact": "",
-    "category": "",
-    "geographic_scope": "",
-    "supporting_organisations": "",
-    "is_ongoing": false,
-    "target_completion_date": null,
-    "is_archived": false,
-    "supply_chain": "107f8ea4-aec0-4bea-b68d-a65720c97022",
-    "slug": "sa-04"
-  }
-},
-{
-  "model": "supply_chains.strategicaction",
-  "pk": "a38838d0-362a-411c-a7c8-65db9981d0bf",
-  "fields": {
-    "name": "SA 02",
-    "start_date": "2009-03-01",
-    "description": "",
-    "impact": "",
-    "category": "",
-    "geographic_scope": "",
-    "supporting_organisations": "",
-    "is_ongoing": false,
-    "target_completion_date": null,
-    "is_archived": false,
-    "supply_chain": "107f8ea4-aec0-4bea-b68d-a65720c97022",
-    "slug": "sa-02"
-  }
-},
-{
-  "model": "supply_chains.strategicaction",
-  "pk": "e3ff7167-9298-45ed-bcca-7c8a923be491",
-  "fields": {
-    "name": "Strategic action 1",
-    "start_date": "1982-03-07",
-    "description": "Cover than item risk difficult.",
-    "impact": "",
-    "category": "",
-    "geographic_scope": "",
-    "supporting_organisations": "",
-    "is_ongoing": false,
-    "target_completion_date": null,
-    "is_archived": false,
-    "supply_chain": "107f8ea4-aec0-4bea-b68d-a65720c97022",
-    "slug": "strategic-action-1"
-  }
-},
-{
-  "model": "supply_chains.strategicaction",
-  "pk": "eec5752e-55ac-4f3e-a96e-75825526b313",
-  "fields": {
-    "name": "Strategic action 2",
-    "start_date": "1984-08-20",
-    "description": "Stock marriage idea add expect visit director.",
-    "impact": "",
-    "category": "",
-    "geographic_scope": "",
-    "supporting_organisations": "",
-    "is_ongoing": false,
-    "target_completion_date": null,
-    "is_archived": false,
-    "supply_chain": "14201f69-2d95-4b4c-9523-b44c6c732a80",
-    "slug": "strategic-action-2"
-  }
-},
-{
-  "model": "supply_chains.strategicaction",
-  "pk": "f12777b8-c2f7-4f1e-ae52-acf79809b0b6",
-  "fields": {
-    "name": "SA 03",
-    "start_date": "2009-03-01",
-    "description": "",
-    "impact": "",
-    "category": "",
-    "geographic_scope": "",
-    "supporting_organisations": "",
-    "is_ongoing": false,
-    "target_completion_date": null,
-    "is_archived": false,
-    "supply_chain": "107f8ea4-aec0-4bea-b68d-a65720c97022",
-    "slug": "sa-03"
-  }
-},
-{
-  "model": "supply_chains.strategicaction",
-  "pk": "fa87e1d4-baaa-4317-89b6-fcade510b015",
-  "fields": {
-    "name": "SA 20",
-    "start_date": "2021-04-06",
-    "description": "Sample 20 asdfdsf adfasdf adsfasdf asdfasdf asdfasdfas asdfasdf",
-    "impact": "None",
-    "category": "Create",
-    "geographic_scope": "uk-wide",
-    "supporting_organisations": "HMT",
-    "is_ongoing": false,
-    "target_completion_date": null,
-    "is_archived": false,
-    "supply_chain": "14201f69-2d95-4b4c-9523-b44c6c732a80",
-    "slug": "sa-20"
-  }
-},
-{
-  "model": "supply_chains.strategicaction",
-  "pk": "fd317f3e-9ce0-4ed0-9a6a-baf7c6e65989",
-  "fields": {
-    "name": "Strategic action 0",
-    "start_date": "1978-03-23",
-    "description": "Garden together job.",
-    "impact": "",
-    "category": "",
-    "geographic_scope": "",
-    "supporting_organisations": "",
-    "is_ongoing": false,
-    "target_completion_date": null,
-    "is_archived": false,
-    "supply_chain": "e7e81077-399f-4004-a907-e0a2862a84de",
-    "slug": "strategic-action-0"
-  }
-}
 ]

--- a/cypress/integration/strategic_action_summary_spec.js
+++ b/cypress/integration/strategic_action_summary_spec.js
@@ -1,0 +1,168 @@
+import govDepartments from '../fixtures/govDepartment.json'
+import supplyChains from '../fixtures/supplyChains.json'
+import users from '../fixtures/user.json'
+import allActions from '../fixtures/strategicActions.json'
+
+const govDepartment = govDepartments[0].fields
+const supplyChain = supplyChains[5] // Uses Supply Chain 6 fixture
+const user = users[0].fields
+const actions = allActions
+  .filter(action => action.fields.supply_chain === supplyChain.pk)
+  .map(action => action.fields)
+
+describe('The strategic action summary page', () => {
+  it('successfully loads', () => {
+    cy.visit(
+      Cypress.config('baseUrl') +
+        `/${supplyChain.fields.slug}/strategic-actions`
+    )
+    cy.injectAxe()
+  })
+  it('has no accessibility issues', () => {
+    cy.runA11y()
+  })
+  it("displays user's name and department in header", () => {
+    cy.get('.app-header-item').should(
+      'have.text',
+      `${user.first_name} ${user.last_name} - ${govDepartment.name}`
+    )
+  })
+  it('displays breadcrumbs', () => {
+    cy.get('li').contains('Home').should('have.attr', 'href').and('eq', '/')
+    cy.get('li')
+      .contains('Strategic actions for Supply Chain 6')
+      .should('have.attr', 'href')
+      .and('eq', `/${supplyChain.fields.slug}/strategic-actions`)
+  })
+  it('displays the header and paragraph text', () => {
+    cy.get('h1').contains(`Strategic actions for ${supplyChain.fields.name}`)
+    cy.get('p').contains('Select a strategic action to edit details.')
+  })
+  it('displays 5 accordian sections with a heading and summary', () => {
+    const checkAccordionHeadingsandSummaries = (object, index) => {
+      cy.get('.govuk-accordion__section')
+        .eq(index)
+        .within(() => {
+          cy.get('.govuk-accordion__section-heading').contains(object.name)
+          cy.get('.govuk-accordion__section-summary').contains(
+            object.description
+          )
+        })
+    }
+
+    cy.get('.govuk-accordion__section').should('have.length', 5)
+    cy.get('.govuk-accordion__section-summary').should('have.length', 5)
+    checkAccordionHeadingsandSummaries(actions[0], 0)
+    checkAccordionHeadingsandSummaries(actions[1], 1)
+    checkAccordionHeadingsandSummaries(actions[2], 2)
+    checkAccordionHeadingsandSummaries(actions[3], 3)
+    checkAccordionHeadingsandSummaries(actions[4], 4)
+  })
+
+  it('opens all sections when open all is clicked', () => {
+    cy.contains('Open all').click()
+    cy.get('div > .govuk-accordion__section-content')
+      .should('be.visible')
+      .and('have.length', 5)
+  })
+  it('closes all sections when close all is clicked', () => {
+    cy.contains('Close all').click()
+    cy.get('div > .govuk-accordion__section-content').should('not.be.visible')
+  })
+  it('opens a section when the + symbol is clicked', () => {
+    cy.get('.govuk-accordion__section-heading > button > span')
+      .first()
+      .click({ force: true })
+    cy.get('div > .govuk-accordion__section-content').should('be.visible')
+  })
+
+  it('displays correct table values', () => {
+    const firstTable = cy
+      .get('.govuk-accordion__section-content > dl')
+      .first()
+      .children()
+
+    const checkTableContent = (index, heading, value) => {
+      firstTable
+        .get('.govuk-summary-list__row')
+        .eq(index)
+        .within(() => {
+          cy.contains(heading)
+          cy.contains(value)
+          cy.get('a').contains('Change')
+        })
+    }
+
+    firstTable.should('have.length', 8)
+    checkTableContent(
+      0,
+      'What does the strategic action involve?',
+      actions[0].description
+    )
+    checkTableContent(
+      1,
+      'What is the intended impact of the strategic action? How will the action be measured?',
+      actions[0].impact
+    )
+    checkTableContent(
+      2,
+      'Which category applies to this strategic action?',
+      'Diversify'
+    )
+    checkTableContent(
+      3,
+      'Does the strategic action apply UK-wide or in England only?',
+      'England only'
+    )
+    checkTableContent(
+      4,
+      'Which other government departments are supporting this strategic action?',
+      'MoD'
+    )
+    checkTableContent(
+      5,
+      'What is the estimated date of completion?',
+      '02/08/2023'
+    )
+    checkTableContent(
+      6,
+      'Are there any other dependencies or requirements for applying this strategic action?',
+      actions[0].other_dependencies
+    )
+    checkTableContent(
+      7,
+      'Does this action affect the whole supply chain or a subset or supply chains?',
+      actions[0].specific_related_products
+    )
+  })
+  it('closes a section with the - symbol is clicked', () => {
+    cy.get('.govuk-accordion__section-heading > button > span')
+      .first()
+      .click({ force: true })
+    cy.get('div > .govuk-accordion__section-content').should('not.be.visible')
+  })
+  it('displays second page of actions when click next', () => {
+    cy.get('li').contains('Next').click()
+    cy.url().should(
+      'eq',
+      Cypress.config('baseUrl') +
+        `/${supplyChain.fields.slug}/strategic-actions?page=2`
+    )
+    cy.get('.govuk-accordion__section').should('have.length', 1)
+  })
+  it('displays first page of actions when click previous', () => {
+    cy.get('li').contains('Previous').click()
+    cy.url().should(
+      'eq',
+      Cypress.config('baseUrl') +
+        `/${supplyChain.fields.slug}/strategic-actions?page=1`
+    )
+  })
+  it('takes user to task list when button is clicked', () => {
+    cy.get('a').contains('Back to task list').click()
+    cy.url().should(
+      'eq',
+      Cypress.config('baseUrl') + `/${supplyChain.fields.slug}`
+    )
+  })
+})

--- a/cypress/integration/task_list_spec.js
+++ b/cypress/integration/task_list_spec.js
@@ -117,7 +117,7 @@ describe('Paginate Strategic actions', () => {
     cy.get('tbody').find('tr').should('have.length', 5)
   })
   it('displays correct items in pagination list', () => {
-    cy.get('.moj-pagination__list').find('li').should('have.length', 4)
+    cy.get('.moj-pagination__list').find('li').should('have.length', 3)
     cy.get('.moj-pagination__item--active').contains('1')
     cy.get('.moj-pagination__item').contains('2')
     cy.get('.moj-pagination__item').contains('Next')

--- a/cypress/integration/task_list_spec.js
+++ b/cypress/integration/task_list_spec.js
@@ -42,6 +42,13 @@ describe('The Supply Chain Tasklist Page', () => {
   it('displays enabled submit button', () => {
     cy.get('button').contains('Submit update')
   })
+  it('links to the strategic action summary page', () => {
+    cy.get('a').contains('Strategic action summary').click()
+    cy.url().should(
+      'eq',
+      Cypress.config('baseUrl') + `/${supplyChain.slug}/strategic-actions`
+    )
+  })
 })
 
 const completedSC = supplyChains[1].fields

--- a/defend_data_capture/conftest.py
+++ b/defend_data_capture/conftest.py
@@ -7,7 +7,10 @@ from rest_framework.test import APIClient
 from accounts.models import User
 from accounts.test.factories import UserFactory
 from supply_chains.models import StrategicActionUpdate
-from supply_chains.test.factories import StrategicActionUpdateFactory
+from supply_chains.test.factories import (
+    StrategicActionUpdateFactory,
+    SupplyChainFactory,
+)
 
 
 @pytest.fixture
@@ -53,3 +56,10 @@ def test_submitted_strategic_action_update():
     update = StrategicActionUpdateFactory(status=StrategicActionUpdate.Status.SUBMITTED)
     update.save()
     yield update
+
+
+@pytest.fixture
+def test_supply_chain():
+    sc = SupplyChainFactory()
+    sc.save()
+    yield sc

--- a/defend_data_capture/defend_data_capture/urls.py
+++ b/defend_data_capture/defend_data_capture/urls.py
@@ -9,7 +9,11 @@ from supply_chains.api_views import (
     SupplyChainViewset,
 )
 from supply_chains import views
-from supply_chains.views import SCTaskListView, SCCompleteView
+from supply_chains.views import (
+    SCTaskListView,
+    SCCompleteView,
+    SASummaryView,
+)
 
 router = routers.DefaultRouter()
 router.register(r"users", UserViewSet, basename="user")
@@ -30,4 +34,9 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("<slug:sc_slug>", SCTaskListView.as_view(), name="tlist"),
     path("<slug:sc_slug>/complete", SCCompleteView.as_view(), name="update_complete"),
+    path(
+        "<slug:sc_slug>/strategic-actions",
+        SASummaryView.as_view(),
+        name="strat_action_summary",
+    ),
 ]

--- a/defend_data_capture/supply_chains/templates/includes/pagination.html
+++ b/defend_data_capture/supply_chains/templates/includes/pagination.html
@@ -1,0 +1,27 @@
+<nav class="moj-pagination govuk-!-margin-bottom-6" aria-label="pagination">
+    <p class="govuk-visually-hidden">Pagination navigation</p>
+    <ul class="moj-pagination__list">
+        {% if objects.has_previous %}
+            <li class="moj-pagination__item  moj-pagination__item--prev">
+                <a class="moj-pagination__link" href="?page={{ objects.previous_page_number }}">Previous<span class="govuk-visually-hidden"> set of pages</span></a>
+            </li>
+        {% endif %}
+        {% for i in objects.paginator.page_range %}
+            {% if objects.number == i %}
+                <li class="moj-pagination__item moj-pagination__item--active">
+                    <span>{{ i }}</span>
+                </li>
+            {% else %}
+                <li class="moj-pagination__item">
+                    <a class="moj-pagination__link" href="?page={{ i }}">{{ i }}</a>
+                </li>
+            {% endif %}
+        {% endfor %}
+        {% if objects.has_next %}
+            <li class="moj-pagination__item  moj-pagination__item--next">
+                <a class="moj-pagination__link" href="?page={{ objects.next_page_number }}">Next<span class="govuk-visually-hidden"> set of pages</span></a>
+            </li>
+        {% endif %}
+    </ul>
+    <p class="moj-pagination__results">Showing <b>{{ objects.start_index }}</b> to <b>{{ objects.end_index }}</b> of <b>{{ objects.paginator.count }}</b> {{ objects_name }}</p>
+</nav>

--- a/defend_data_capture/supply_chains/templates/index.html
+++ b/defend_data_capture/supply_chains/templates/index.html
@@ -1,8 +1,7 @@
 {% extends "base.html" %}
 
 {% block body %}
-
-    <h1 class="govuk-heading-l"> Update supply chain information for {{ gov_department_name }}</h1>
+    <h1 class="govuk-heading-l">Update supply chain information for {{ gov_department_name }}</h1>
 
     <p class="govuk-body">
         This service is designed to record updates to departmental action plans for
@@ -53,33 +52,7 @@
         </tbody>
     </table>
     {% if supply_chains.has_other_pages %}
-        <nav class="moj-pagination" aria-label="pagination">
-            <p class="govuk-visually-hidden">Pagination navigation</p>
-            <ul class="moj-pagination__list">
-                {% if supply_chains.has_previous %}
-                    <li class="moj-pagination__item  moj-pagination__item--prev">
-                        <a class="moj-pagination__link" href="?page={{ supply_chains.previous_page_number }}">Previous<span class="govuk-visually-hidden"> set of pages</span></a>
-                    </li>
-                {% endif %}
-                {% for i in supply_chains.paginator.page_range %}
-                    {% if supply_chains.number == i %}
-                        <li class="moj-pagination__item moj-pagination__item--active">
-                            <span>{{ i }}</span>
-                        </li>
-                    {% else %}
-                        <li class="moj-pagination__item">
-                            <a class="moj-pagination__link" href="?page={{ i }}">{{ i }}</a>
-                        </li>
-                    {% endif %}
-                {% endfor %}
-                {% if supply_chains.has_next %}
-                    <li class="moj-pagination__item  moj-pagination__item--next">
-                        <a class="moj-pagination__link" href="?page={{ supply_chains.next_page_number }}">Next<span class="govuk-visually-hidden"> set of pages</span></a>
-                    </li>
-                {% endif %}
-            </ul>
-            <p class="moj-pagination__results">Showing <b>{{ supply_chains.start_index }}</b> to <b>{{ supply_chains.end_index }}</b> of <b>{{ supply_chains.paginator.count }}</b> supply chains</p>
-        </nav>
+        {% include 'includes/pagination.html' with objects=supply_chains objects_name="supply chains" %} 
     {% endif %}
 
 {% endblock %}

--- a/defend_data_capture/supply_chains/templates/strategic_action_summary.html
+++ b/defend_data_capture/supply_chains/templates/strategic_action_summary.html
@@ -1,0 +1,153 @@
+{% extends "base.html" %}
+{% block breadcrumbs %}
+<nav class="govuk-breadcrumbs" aria-label="breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="{% url 'index' %}">Home</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="{% url 'strat_action_summary' supply_chain.slug %}">Strategic actions for {{ supply_chain.name }}</a>
+    </li>
+  </ol>
+</nav>
+{% endblock %}
+{% block body %}
+<h1 class="govuk-heading-xl">Strategic actions for
+  <br>
+  {{ supply_chain.name }}</h1>
+<p class="govuk-body">Select a strategic action to view and edit its details.</p>
+<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-with-summary-sections">
+  {% for action in strategic_actions %}
+  <div class="govuk-accordion__section">
+    <div class="govuk-accordion__section-header">
+      <h2 class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="accordion-section-heading-{{ action.name|slugify }}">
+          {{ action.name }}
+        </span>
+      </h2>
+      <div class="govuk-accordion__section-summary govuk-body" id="accordion-section-summary-{{ action.name|slugify }}">
+        {{ action.description|truncatechars:150 }}
+      </div>
+    </div>
+    <div id="accordion-section-content-{{ action.name|slugify }}" class="govuk-accordion__section-content" aria-labelledby="accordion-section-heading-{{ action.name|slugify }}">
+      <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              What does the strategic action involve?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ action.description|default:"No information" }}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> description</span>
+              </a>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              What is the intended impact of the strategic action?
+              <br>
+              How will the action be measured?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ action.impact|default:"No information" }}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> impact</span>
+              </a>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Which category applies to this strategic action?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ action.get_category_display|default:"No information" }}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> category</span>
+              </a>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Does the strategic action apply UK-wide or in England only?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ action.get_geographic_scope_display|default:"No information" }}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> geographic scope</span>
+              </a>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Which other government departments are supporting this strategic action?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ action.get_supporting_organisations_display|default:"No information" }}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> supporting departments</span>
+              </a>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              What is the estimated date of completion?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {% if action.is_ongoing %}
+              Ongoing
+              {% else %}
+              {{ action.target_completion_date|date:"SHORT_DATE_FORMAT"|default:"No information" }}
+              {% endif %}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> date of intended completion</span>
+              </a>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Are there any other dependencies or requirements for applying this strategic action?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ action.other_dependencies|default:"No information" }}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> other dependencies</span>
+              </a>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row govuk-summary-list--no-border">
+            <dt class="govuk-summary-list__key">
+              Does this action affect the whole supply chain or a section of supply chains?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ action.specific_related_products|default:"No information" }}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="#">
+                Change<span class="govuk-visually-hidden"> specific products the action relates to</span>
+              </a>
+            </dd>
+          </div>
+      </dl>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% if strategic_actions.has_other_pages %}
+    {% include 'includes/pagination.html' with objects=strategic_actions objects_name="strategic actions" %}
+{% endif %}
+<a class="govuk-button govuk-button--secondary" data-module="govuk-button" href="{% url 'tlist' supply_chain.slug %}">Back to task list</a>
+{% endblock %}

--- a/defend_data_capture/supply_chains/templates/task_list.html
+++ b/defend_data_capture/supply_chains/templates/task_list.html
@@ -106,38 +106,8 @@
     </table>
 
     {% if view.sa_updates.has_other_pages %}
-            <nav class="moj-pagination" aria-label="pagination">
-                <ul class="moj-pagination__list">
-                    {% if view.sa_updates.has_previous %}
-                        <li class="moj-pagination__item  moj-pagination__item--prev">
-                            <a class="moj-pagination__link" href="?page={{ view.sa_updates.previous_page_number }}">Previous<span class="govuk-visually-hidden"> set of pages</span></a>
-                        </li>
-                    {% else %}
-                        <li class="disabled"><span>&laquo;</span></li>
-                    {% endif %}
-                    {% for i in view.sa_updates.paginator.page_range %}
-                        {% if view.sa_updates.number == i %}
-                            <li class="moj-pagination__item moj-pagination__item--active">
-                                <span>{{ i }}</span>
-                            </li>
-                        {% else %}
-                            <li class="moj-pagination__item">
-                                <a class="moj-pagination__link" href="?page={{ i }}">{{ i }}</a>
-                            </li>
-                        {% endif %}
-                    {% endfor %}
-                    {% if view.sa_updates.has_next %}
-                        <li class="moj-pagination__item  moj-pagination__item--next">
-                            <a class="moj-pagination__link" href="?page={{ view.sa_updates.next_page_number }}">Next<span class="govuk-visually-hidden"> set of pages</span></a>
-                        </li>
-                    {% else %}
-                        <li class="disabled"><span>&raquo;</span></li>
-                    {% endif %}
-                </ul>
-                <p class="moj-pagination__results">Displaying strategic actions <b>{{ view.sa_updates.start_index }}</b> - <b>{{ view.sa_updates.end_index }}</b> of <b>{{ view.sa_updates.paginator.count }}</b></p>
-            </nav>
-        {% endif %}
-    <br>
+        {% include 'includes/pagination.html' with objects=view.sa_updates objects_name="strategic actions" %} 
+    {% endif %}
 
     {% if not view.update_submitted %}
         <h2 class="govuk-heading-l">Before you submit</h2>

--- a/defend_data_capture/supply_chains/templates/task_list.html
+++ b/defend_data_capture/supply_chains/templates/task_list.html
@@ -123,7 +123,7 @@
                 </span>
             </li>
             <li>
-                <a href="#" class="govuk-link">Strategic action summary</a>
+                <a href="{% url 'strat_action_summary' view.supply_chain.slug %}" class="govuk-link">Strategic action summary</a>
                 <span>
                     - description of the action, impact, strategic action framework category and depedencies
                 </span>

--- a/defend_data_capture/supply_chains/test/factories.py
+++ b/defend_data_capture/supply_chains/test/factories.py
@@ -29,13 +29,15 @@ class SupplyChainFactory(factory.django.DjangoModelFactory):
 class StrategicActionFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: f"Strategic action {n}")
     start_date = factory.Faker("date_object")
-    description = factory.Faker("sentence")
-    impact = factory.Faker("sentence")
+    description = factory.Faker("text")
+    impact = factory.Faker("text")
     category = factory.fuzzy.FuzzyChoice(StrategicAction.Category)
     geographic_scope = factory.fuzzy.FuzzyChoice(StrategicAction.GeographicScope)
     supporting_organisations = factory.fuzzy.FuzzyChoice(StrategicAction.SupportingOrgs)
     target_completion_date = factory.Faker("date_object")
     is_archived = False
+    specific_related_products = factory.Faker("text")
+    other_dependencies = factory.Faker("text")
     supply_chain = factory.SubFactory(SupplyChainFactory)
 
     class Meta:
@@ -45,7 +47,7 @@ class StrategicActionFactory(factory.django.DjangoModelFactory):
 class StrategicActionUpdateFactory(factory.django.DjangoModelFactory):
     submission_date = factory.Faker("date_object")
     date_created = date.today()
-    content = factory.Faker("sentence")
+    content = factory.Faker("text")
     implementation_rag_rating = factory.fuzzy.FuzzyChoice(
         RAGRating,
     )

--- a/defend_data_capture/supply_chains/test/factories.py
+++ b/defend_data_capture/supply_chains/test/factories.py
@@ -12,7 +12,7 @@ from supply_chains.models import (
 
 
 class SupplyChainFactory(factory.django.DjangoModelFactory):
-    name = "Product"
+    name = factory.Sequence(lambda n: f"Product {n}")
     last_submission_date = factory.Faker("date_object")
     gov_department = factory.SubFactory(GovDepartmentFactory)
     contact_name = factory.Faker("name")

--- a/defend_data_capture/supply_chains/test/test_utils.py
+++ b/defend_data_capture/supply_chains/test/test_utils.py
@@ -2,9 +2,13 @@ import pytest
 
 from datetime import date
 
+from accounts.test.factories import GovDepartmentFactory, UserFactory
+from supply_chains.models import SupplyChain
+from supply_chains.test.factories import SupplyChainFactory
 from supply_chains.utils import (
     get_last_working_day_of_a_month,
     get_last_working_day_of_previous_month,
+    check_matching_gov_department,
 )
 
 
@@ -18,3 +22,20 @@ from supply_chains.utils import (
 )
 def test_get_last_working_day_of_a_month(input_date, expected_date):
     assert get_last_working_day_of_a_month(input_date) == expected_date
+
+
+@pytest.mark.django_db()
+def test_check_matching_gov_department_fail():
+    """Test False returned if supply chain and user have different gov departments."""
+    user = UserFactory()
+    supply_chain = SupplyChainFactory()
+    assert not check_matching_gov_department(user, supply_chain)
+
+
+@pytest.mark.django_db()
+def test_check_matching_gov_department_success():
+    """Test True is returned if supply chain and user have same gov department."""
+    g = GovDepartmentFactory()
+    user = UserFactory(gov_department=g)
+    supply_chain = SupplyChainFactory(gov_department=g)
+    assert check_matching_gov_department(user, supply_chain)

--- a/defend_data_capture/supply_chains/utils.py
+++ b/defend_data_capture/supply_chains/utils.py
@@ -2,7 +2,11 @@ import calendar
 from datetime import date, datetime, timedelta
 
 import holidays
+from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+
+from accounts.models import User
+from supply_chains.models import SupplyChain
 
 
 def get_last_working_day_of_a_month(last_day_of_month: date) -> date:
@@ -38,6 +42,26 @@ class PaginationMixin:
             paged_object = paginator.page(paginator.num_pages)
 
         return paged_object
+
+
+def check_matching_gov_department(user: User, supply_chain: SupplyChain):
+    """Check user's gov department matches that of a supply chain."""
+    return user.gov_department == supply_chain.gov_department
+
+
+class GovDepPermissionMixin:
+    """
+    A mixin which will rasie a 403 forbidden error if
+    a user tries to access a URL for a supply chain not
+    linked to their gov department.
+    """
+
+    def dispatch(self, *args, **kwargs):
+        supply_chain = SupplyChain.objects.get(slug=kwargs.get("sc_slug"))
+
+        if not check_matching_gov_department(self.request.user, supply_chain):
+            raise PermissionDenied
+        return super().dispatch(*args, **kwargs)
 
 
 def get_last_working_day_of_previous_month() -> date:

--- a/defend_data_capture/supply_chains/views.py
+++ b/defend_data_capture/supply_chains/views.py
@@ -17,6 +17,7 @@ from supply_chains.utils import (
     get_last_working_day_of_a_month,
     get_last_working_day_of_previous_month,
     PaginationMixin,
+    GovDepPermissionMixin,
 )
 
 
@@ -195,3 +196,20 @@ class SCCompleteView(LoginRequiredMixin, TemplateView):
 
         kwargs.setdefault("view", self)
         return render(request, self.template_name, context=kwargs)
+
+
+class SASummaryView(
+    LoginRequiredMixin, GovDepPermissionMixin, PaginationMixin, TemplateView
+):
+    template_name = "strategic_action_summary.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        supply_chain = SupplyChain.objects.get(slug=kwargs.get("sc_slug"))
+
+        context["strategic_actions"] = self.paginate(
+            supply_chain.strategic_actions.filter(is_archived=False).order_by("name"),
+            5,
+        )
+        context["supply_chain"] = supply_chain
+        return context


### PR DESCRIPTION
This PR adds the 'Strategic action summary page', which displays details of all the active (i.e un-archived) strategic actions linked to a given supply chain. [Design here](https://xd.adobe.com/view/9a58e0ae-80ef-48cb-88b2-150c67f2b659-cf0b/screen/1da20235-b93f-4438-a343-f49d2a8f9939)

**User flow**

- User visits `/supply-chain/strategic-actions` from clicking the 'Strategic action summary' link on the task list page
- User sees a paginated list of all unarchived strategic actions for that supply chain
- User can see details of a strategic action by clicking either the action name or the + symbol
- (Not covered in this PR) User can click the 'change' link next to a field and update that piece of information


**Also included**

This PR also includes:
- The abstraction of the pagination component into an 'includes' template which will avoid the repetition of the component's code
- A mixin `GovDepPermissionMixin` which checks that the current user has the same gov department as the supply chain in the url, and returns a 403 forbidden page if not (custom template for this page to come after design is done). This doesn't actually use Django's permissions module, so any feedback on whether this is an appropriate way to do it would be v appreciated!

**Screenshot**

![Screenshot 2021-04-26 at 11 41 06](https://user-images.githubusercontent.com/22460823/116070266-4d6fd280-a684-11eb-8231-75942cef84ea.png)
