### PR TITLE
Fix functional test script bug & failing tests

### DIFF
--- a/cypress/integration/strategic_action_summary_spec.js
+++ b/cypress/integration/strategic_action_summary_spec.js
@@ -36,7 +36,9 @@ describe('The strategic action summary page', () => {
   })
   it('displays the header and paragraph text', () => {
     cy.get('h1').contains(`Strategic actions for ${supplyChain.fields.name}`)
-    cy.get('p').contains('Select a strategic action to edit details.')
+    cy.get('p').contains(
+      'Select a strategic action to view and edit its details.'
+    )
   })
   it('displays 5 accordian sections with a heading and summary', () => {
     const checkAccordionHeadingsandSummaries = (object, index) => {
@@ -131,7 +133,7 @@ describe('The strategic action summary page', () => {
     )
     checkTableContent(
       7,
-      'Does this action affect the whole supply chain or a subset or supply chains?',
+      'Does this action affect the whole supply chain or a section of supply chains?',
       actions[0].specific_related_products
     )
   })

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -17,9 +17,13 @@ python defend_data_capture/manage.py testserver \
     & echo $! > backend.pid \
     & (sleep 5 && npx cypress run --headless --browser chrome)
 
+cypress_failed=$?
+
 if [ "$running_locally" == true ]; then
     # Kill the application using the pid previously saved
     kill $(cat backend.pid)
     # Drop the test database
     docker-compose exec db psql -h localhost -U postgres -c "DROP DATABASE IF EXISTS test_defend"
 fi
+
+exit $cypress_failed


### PR DESCRIPTION
This PR fixes a bug with the github action which runs tests against a PR. 

Previously, the exit code from cypress (i.e the number of tests failing from the functional test suite) was not being returned from the `run_functional_tests.sh` script. This was because the status code of the the if statement was instead being returned. 

I have added the exit code from the cypress tests to a variable and then call exit with that variable at the bottom of the file. 

As a PR with failing tests cannot be merged, I have also fixed two failing tests in the `supply_chain_summary_spec.js` which had been merged into main due to the bug in the script.

**Example**
An example of the tests successfully failing can be found in this [action run](https://github.com/uktrade/defend-data-capture/actions/runs/789322236).