### PR TITLE
Refactor index view to be class based

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Where it is not possible to use a govuk style, the [moj-frontend](https://github
 The project uses the [cypress-axe](https://github.com/component-driven/cypress-axe) package which allows for the automation of accessibility testing within tests written with cypress.
 
 To add accessibility testing to a cypress spec:
-- Add the command `cy.injectA11y()` after wherever `cy.visit(url)` is called. This injects the axe-core runtime into the page being tested.
+- Add the command `cy.injectAxe()` after wherever `cy.visit(url)` is called. This injects the axe-core runtime into the page being tested.
 - Add a test to check for accessibility issues on a page using the command `cy.runA11y()`. This will output details of any accessibility violations into a table in the terminal where cypress is running.
 
 ## Adding Black pre-commit hook

--- a/defend_data_capture/defend_data_capture/urls.py
+++ b/defend_data_capture/defend_data_capture/urls.py
@@ -8,8 +8,8 @@ from supply_chains.api_views import (
     StrategicActionUpdateViewset,
     SupplyChainViewset,
 )
-from supply_chains import views
 from supply_chains.views import (
+    HomePageView,
     SCTaskListView,
     SCCompleteView,
     SASummaryView,
@@ -32,7 +32,7 @@ urlpatterns = [
     path("auth/", include("authbroker_client.urls")),
     path("admin/", admin.site.urls),
     path("api/", include(router.urls)),
-    path("", views.index, name="index"),
+    path("", HomePageView.as_view(), name="index"),
     path("<slug:sc_slug>/summary", SCSummary.as_view(), name="sc_summary"),
     path("<slug:sc_slug>", SCTaskListView.as_view(), name="tlist"),
     path("<slug:sc_slug>/complete", SCCompleteView.as_view(), name="update_complete"),

--- a/defend_data_capture/supply_chains/test/test_views.py
+++ b/defend_data_capture/supply_chains/test/test_views.py
@@ -26,9 +26,11 @@ def test_homepage_user_redirected():
 def test_homepage_pagination(
     num_supply_chains, logged_in_client, test_user, url, num_supply_chains_returned
 ):
-    """
-    Test correct number of supply chains are passed to homepage via context
-    depending on total number linked to the user's department.
+    """Test pagination of supply chains on homepage.
+
+    Check the correct number of supply chains are passed to homepage
+    via context depending on total number linked to the user's department,
+    and that the supply chains are annotated with 'strategic_action_count'.
     """
     SupplyChainFactory.create_batch(
         num_supply_chains, gov_department=test_user.gov_department
@@ -37,12 +39,15 @@ def test_homepage_pagination(
     assert response.status_code == 200
     assert response.context["gov_department_name"] == test_user.gov_department.name
     assert len(response.context["supply_chains"]) == num_supply_chains_returned
+    assert hasattr(response.context["supply_chains"][0], "strategic_action_count")
 
 
 def test_homepage_update_complete(logged_in_client, test_user):
-    """
-    Test update_complete is True in context passed to homepage when all supply chains
-    linked to the user's gov department have a last_submission date after last deadline.
+    """Test update_complete is True.
+
+    'update_complete' should be True in context passed to homepage when all supply
+    chains linked to the user's gov department have a last_submission date after
+    last deadline.
     """
     SupplyChainFactory.create_batch(
         6, gov_department=test_user.gov_department, last_submission_date=date.today()
@@ -54,10 +59,11 @@ def test_homepage_update_complete(logged_in_client, test_user):
 
 
 def test_homepage_update_incomplete(logged_in_client, test_user):
-    """
-    Test update_complete is False in context passed to homepage when not all supply
-    chains linked to the user's gov department have a last_submission date after
-    last deadline.
+    """Test update_complete is False.
+
+    'update_complete' should be False in context passed to homepage when not all
+    supply chains linked to the user's gov department have a last_submission date
+    after last deadline.
     """
     SupplyChainFactory.create_batch(
         3, gov_department=test_user.gov_department, last_submission_date=date.today()

--- a/defend_data_capture/supply_chains/views.py
+++ b/defend_data_capture/supply_chains/views.py
@@ -7,7 +7,7 @@ from django.http import HttpResponse
 from django.template import loader
 from django.db.models import Count, QuerySet
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.views.generic import TemplateView
+from django.views.generic import ListView, TemplateView
 from django.shortcuts import redirect, render
 
 from supply_chains.models import SupplyChain, StrategicAction, StrategicActionUpdate
@@ -21,38 +21,33 @@ from supply_chains.utils import (
 )
 
 
-@login_required
-def index(request):
-    supply_chains = request.user.gov_department.supply_chains.order_by("name")
-    all_supply_chains = supply_chains.annotate(
-        strategic_action_count=Count("strategic_actions")
-    )
+class HomePageView(LoginRequiredMixin, PaginationMixin, ListView):
+    model = SupplyChain
+    context_object_name = "supply_chains"
+    template_name = "index.html"
 
-    deadline = get_last_working_day_of_a_month(get_last_day_of_this_month())
-    last_deadline = get_last_working_day_of_previous_month()
+    def get_queryset(self):
+        return self.request.user.gov_department.supply_chains.annotate(
+            strategic_action_count=Count("strategic_actions")
+        ).order_by("name")
 
-    num_updated_supply_chains = all_supply_chains.submitted_since(last_deadline).count()
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        last_deadline = get_last_working_day_of_previous_month()
 
-    page = request.GET.get("page", 1)
-    paginator = Paginator(all_supply_chains, 5)
+        context["supply_chains"] = self.paginate(self.object_list, 5)
+        context["deadline"] = get_last_working_day_of_a_month(
+            get_last_day_of_this_month()
+        )
+        context["num_updated_supply_chains"] = self.object_list.submitted_since(
+            last_deadline
+        ).count()
+        context["gov_department_name"] = self.request.user.gov_department.name
+        context["update_complete"] = (
+            context["num_updated_supply_chains"] == self.object_list.count()
+        )
 
-    try:
-        supply_chains = paginator.page(page)
-    except PageNotAnInteger:
-        supply_chains = paginator.page(1)
-    except EmptyPage:
-        supply_chains = paginator.page(paginator.num_pages)
-
-    template = loader.get_template("index.html")
-
-    context = {
-        "supply_chains": supply_chains,
-        "gov_department_name": request.user.gov_department.name,
-        "deadline": deadline,
-        "num_updated_supply_chains": num_updated_supply_chains,
-        "update_complete": num_updated_supply_chains == all_supply_chains.count(),
-    }
-    return HttpResponse(template.render(context, request))
+        return context
 
 
 class SCSummary(LoginRequiredMixin, TemplateView):


### PR DESCRIPTION
This PR refactors the index view - now `HomePageView` - to be class-based rather than a function, to keep consistency between the views.

I also:
- noticed I hadn't previously added a test to make sure that the annotation on the supply_chain queryset is present, so have added an extra assertion to one of the homepage unit tests. 
- reformatted the docstrings of the homepage unit tests to be in line with PEP guidelines
- Corrected the `cy.injectAxe` command in the Readme, as it incorrectly showed `cy.injectA11y()`