### PR TITLE
Make breadcrumbs consistent across pages

### DIFF
--- a/cypress/integration/sc_summary_spec.js
+++ b/cypress/integration/sc_summary_spec.js
@@ -8,10 +8,7 @@ const user = users[0].fields
 
 describe('Supply chain summary page', () => {
   it('successfully loads', () => {
-    cy.visit(
-      Cypress.config('baseUrl') +
-      `/${supplyChain.fields.slug}/summary`
-    )
+    cy.visit(Cypress.config('baseUrl') + `/${supplyChain.fields.slug}/summary`)
     cy.injectAxe()
   })
   it('has no accessibility issues', () => {
@@ -32,7 +29,7 @@ describe('Supply chain summary page', () => {
     cy.get('li')
       .contains(`Full details of ${supplyChain.fields.name}`)
       .should('have.attr', 'href')
-      .and('eq', `#`)
+      .and('eq', `/${supplyChain.fields.slug}/summary`)
   })
   it('displays the header', () => {
     cy.get('h1').contains(`Summary of ${supplyChain.fields.name}`)
@@ -43,7 +40,7 @@ describe('Supply chain summary page', () => {
       'Vulnerability assessment',
       'Scenario assessment',
       'Maturity self assessment',
-      'Risk monitoring'
+      'Risk monitoring',
     ]
 
     cy.get('#accordion-default').should('have.length', 1)
@@ -91,7 +88,6 @@ describe('Supply chain summary page', () => {
       editLabel
     )
 
-
     cy.forms.checkSummaryTableContent(
       table,
       tableElement,
@@ -112,13 +108,11 @@ describe('Supply chain summary page', () => {
     cy.get('div > .govuk-accordion__section-content').should('not.be.visible')
   })
   it('opens a section when the + symbol is clicked', () => {
-    cy.get('#accordion-default-heading-1')
-      .click()
+    cy.get('#accordion-default-heading-1').click()
     cy.get('#accordion-default-content-1').should('be.visible')
   })
   it('closes a section when the - symbol is clicked', () => {
-    cy.get('#accordion-default-heading-1')
-      .click()
+    cy.get('#accordion-default-heading-1').click()
     cy.get('#accordion-default-content-1').should('be.not.visible')
   })
   it('takes user to task list when button is clicked', () => {

--- a/cypress/integration/strategic_action_summary_spec.js
+++ b/cypress/integration/strategic_action_summary_spec.js
@@ -30,7 +30,11 @@ describe('The strategic action summary page', () => {
   it('displays breadcrumbs', () => {
     cy.get('li').contains('Home').should('have.attr', 'href').and('eq', '/')
     cy.get('li')
-      .contains('Strategic actions for Supply Chain 6')
+      .contains(`${supplyChain.fields.name}`)
+      .should('have.attr', 'href')
+      .and('eq', `/${supplyChain.fields.slug}`)
+    cy.get('li')
+      .contains(`Strategic actions for ${supplyChain.fields.name}`)
       .should('have.attr', 'href')
       .and('eq', `/${supplyChain.fields.slug}/strategic-actions`)
   })

--- a/cypress/integration/task_complete_spec.js
+++ b/cypress/integration/task_complete_spec.js
@@ -2,7 +2,6 @@ import users from '../fixtures/user.json'
 import govDepartments from '../fixtures/govDepartment.json'
 import supplyChains from '../fixtures/supplyChains.json'
 
-
 const user = users[0].fields
 const govDepartment = govDepartments[0].fields
 const supplyChain = supplyChains[4].fields
@@ -21,26 +20,32 @@ describe('The Supply Chain TaskComplete Page', () => {
       `${user.first_name} ${user.last_name} - ${govDepartment.name}`
     )
   })
-  it('displays bread crumbs', () => {
-    cy.get('li').contains('Home')
-    cy.get('li').contains('Update complete')
+  it('displays breadcrumbs', () => {
+    cy.get('li').contains('Home').should('have.attr', 'href').and('eq', '/')
+    cy.get('li')
+      .contains(supplyChain.name)
+      .should('have.attr', 'href')
+      .and('eq', `/${supplyChain.slug}`)
+    cy.get('li')
+      .contains('Update complete')
+      .should('have.attr', 'href')
+      .and('eq', `/${supplyChain.slug}/complete`)
   })
   it('displays the correct text', () => {
     cy.get('h1').contains('Update complete')
-    cy.get('div')
-      .contains(`Thank you for submitting your monthly update for the ${supplyChain.name} supply chain.`)
+    cy.get('div').contains(
+      `Thank you for submitting your monthly update for the ${supplyChain.name} supply chain.`
+    )
   })
   it('displays the correct inset text', () => {
-    cy.get('div')
-      .contains(`You have given updates for 1 of 6 supply chains.`)
+    cy.get('div').contains(`You have given updates for 1 of 6 supply chains.`)
   })
   it('displays the correct link back to home', () => {
-    cy.get('p')
-      .contains('You can go back and give an update for another supply chain.')
+    cy.get('p').contains(
+      'You can go back and give an update for another supply chain.'
+    )
 
-    cy.get('#home')
-      .should('have.attr', 'href')
-      .and('equal', '/')
+    cy.get('#home').should('have.attr', 'href').and('equal', '/')
   })
 })
 
@@ -50,9 +55,12 @@ describe('Validate complete view for manual access', () => {
   it('successfully loads completed un-submitted Supply chain, by redirecting to tasklist page', () => {
     cy.visit(Cypress.config('baseUrl') + `/${completedSC.slug}/complete`)
   })
-  it('displays bread crumbs', () => {
-    cy.get('li').contains('Home')
-    cy.get('li').contains(`Update ${completedSC.name}`)
+  it('displays breadcrumbs', () => {
+    cy.get('li').contains('Home').should('have.attr', 'href').and('eq', `/`)
+    cy.get('li')
+      .contains(completedSC.name)
+      .should('have.attr', 'href')
+      .and('eq', `/${completedSC.slug}`)
   })
   it('displays the correct header', () => {
     cy.get('h1').contains(`Update ${completedSC.name}`)

--- a/cypress/integration/task_list_spec.js
+++ b/cypress/integration/task_list_spec.js
@@ -2,7 +2,6 @@ import users from '../fixtures/user.json'
 import govDepartments from '../fixtures/govDepartment.json'
 import supplyChains from '../fixtures/supplyChains.json'
 
-
 const user = users[0].fields
 const govDepartment = govDepartments[0].fields
 const supplyChain = supplyChains[0].fields
@@ -21,9 +20,12 @@ describe('The Supply Chain Tasklist Page', () => {
       `${user.first_name} ${user.last_name} - ${govDepartment.name}`
     )
   })
-  it('displays bread crumbs', () => {
-    cy.get('li').contains('Home')
-    cy.get('li').contains(`Update ${supplyChain.name}`)
+  it('displays breadcrumbs', () => {
+    cy.get('li').contains('Home').should('have.attr', 'href').and('eq', `/`)
+    cy.get('li')
+      .contains(`${supplyChain.name}`)
+      .should('have.attr', 'href')
+      .and('eq', `/${supplyChain.slug}`)
   })
   it('displays the correct header', () => {
     cy.get('h1').contains(`Update ${supplyChain.name}`)
@@ -70,12 +72,15 @@ describe('Allowed to submit completed Supply Chains', () => {
   it('displays enabled submit button', () => {
     cy.get('button').contains('Submit update')
   })
-  if (Cypress.env("RUNNING_LOCALLY") === '0') {
+  if (Cypress.env('RUNNING_LOCALLY') === '0') {
     // This test will only be run on CI or non-local environments as its un-safe operation
     // which alters state of objects(with the given fixtures)
     it('can submit updates for supply chain', () => {
       cy.get('form').find('button').click()
-      cy.url().should('eq', Cypress.config('baseUrl') + `/${completedSC.slug}/complete`)
+      cy.url().should(
+        'eq',
+        Cypress.config('baseUrl') + `/${completedSC.slug}/complete`
+      )
       cy.get('li').contains('Home')
       cy.get('li').contains('Update complete')
     })
@@ -92,7 +97,9 @@ describe('Allowed to view submitted Supply chain', () => {
     cy.get('h1').contains(`Update ${submittedSC.name}`)
     cy.get('div').contains(`Update complete`).should('not.exist')
     cy.get('h2').contains('No action required')
-    cy.get('p').contains('You have already submitted the monthly update for this supply chain.')
+    cy.get('p').contains(
+      'You have already submitted the monthly update for this supply chain.'
+    )
     cy.get('h2').contains('Before you submit').should('not.exist')
   })
   it('displays correct table headers', () => {
@@ -105,11 +112,20 @@ describe('Allowed to view submitted Supply chain', () => {
     cy.get('td').contains('submitted')
   })
   it('displays strategic action name with hyperlink', () => {
-    cy.get('td').find('a').invoke('text').should('match', /Update .*$/)
-    cy.get('td').find('a').should('have.attr', 'href').and('match', /supply-chain-5.*/)
+    cy.get('td')
+      .find('a')
+      .invoke('text')
+      .should('match', /Update .*$/)
+    cy.get('td')
+      .find('a')
+      .should('have.attr', 'href')
+      .and('match', /supply-chain-5.*/)
   })
   it('displays button to go back', () => {
-    cy.get('a').contains('Back to home').should('have.attr', 'href').and('equal', '/')
+    cy.get('a')
+      .contains('Back to home')
+      .should('have.attr', 'href')
+      .and('equal', '/')
     cy.get('form').should('not.exist')
   })
 })
@@ -159,9 +175,10 @@ describe('Error handling while submitting in-complete updates', () => {
     cy.get('form').find('button').click()
     cy.url().should('eq', Cypress.config('baseUrl') + `/${largeSC.slug}`)
     cy.get('#error-summary-title').contains('There is a problem')
-    cy.get('li').find('a')
-    .contains('Updates must be given for all strategic actions')
-    .should('have.attr', 'href')
-    .and('equal', '#updates')
+    cy.get('li')
+      .find('a')
+      .contains('Updates must be given for all strategic actions')
+      .should('have.attr', 'href')
+      .and('equal', '#updates')
   })
 })

--- a/defend_data_capture/supply_chains/templates/sc_summary.html
+++ b/defend_data_capture/supply_chains/templates/sc_summary.html
@@ -5,13 +5,13 @@
 <nav class="govuk-breadcrumbs" aria-label="breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href={% url 'index' %}>Home</a>
+        <a class="govuk-breadcrumbs__link" href="{% url 'index' %}">Home</a>
       </li>
       <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href={% url 'tlist' sc_slug=supply_chain.slug %}>{{ supply_chain.name }}</a>
+        <a class="govuk-breadcrumbs__link" href="{% url 'tlist' sc_slug=supply_chain.slug %}">{{ supply_chain.name }}</a>
       </li>
       <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#">Full details of {{ supply_chain.name }}</a>
+        <a class="govuk-breadcrumbs__link" href="{% url 'sc_summary' sc_slug=supply_chain.slug %}" aria-current="page">Full details of {{ supply_chain.name }}</a>
       </li>
     </ol>
   </nav>

--- a/defend_data_capture/supply_chains/templates/strategic_action_summary.html
+++ b/defend_data_capture/supply_chains/templates/strategic_action_summary.html
@@ -6,7 +6,10 @@
       <a class="govuk-breadcrumbs__link" href="{% url 'index' %}">Home</a>
     </li>
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="{% url 'strat_action_summary' supply_chain.slug %}">Strategic actions for {{ supply_chain.name }}</a>
+      <a class="govuk-breadcrumbs__link" href="{% url 'tlist' supply_chain.slug %}">{{ supply_chain.name }}</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="{% url 'strat_action_summary' supply_chain.slug %}" aria-current="page">Strategic actions for {{ supply_chain.name }}</a>
     </li>
   </ol>
 </nav>

--- a/defend_data_capture/supply_chains/templates/task_complete.html
+++ b/defend_data_capture/supply_chains/templates/task_complete.html
@@ -4,10 +4,13 @@
 <nav class="govuk-breadcrumbs" aria-label="breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
         <li class="govuk-breadcrumbs__list-item">
-            <a class="govuk-breadcrumbs__link" href={% url 'index' %}>Home</a>
+            <a class="govuk-breadcrumbs__link" href="{% url 'index' %}">Home</a>
         </li>
         <li class="govuk-breadcrumbs__list-item">
-            <a class="govuk-breadcrumbs__link" href="#">Update complete</a>
+            <a class="govuk-breadcrumbs__link" href="{% url 'tlist' view.supply_chain.slug %}">{{ view.supply_chain.name }}</a>
+        </li>
+        <li class="govuk-breadcrumbs__list-item">
+            <a class="govuk-breadcrumbs__link" href="{% url 'update_complete' view.supply_chain.slug %}" aria-current="page">Update complete</a>
         </li>
     </ol>
 </nav>

--- a/defend_data_capture/supply_chains/templates/task_list.html
+++ b/defend_data_capture/supply_chains/templates/task_list.html
@@ -4,10 +4,10 @@
 <nav class="govuk-breadcrumbs" aria-label="breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href={% url 'index' %}>Home</a>
+        <a class="govuk-breadcrumbs__link" href="{% url 'index' %}">Home</a>
       </li>
       <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#">Update {{ view.supply_chain.name }}</a>
+        <a class="govuk-breadcrumbs__link" href="{% url 'tlist' view.supply_chain.slug %}" aria-current="page">{{ view.supply_chain.name }}</a>
       </li>
     </ol>
 </nav>


### PR DESCRIPTION
This PR makes the breadcrumbs structure on the existing pages consistent.

It also:
- updates all tests to check the links of breadcrumbs
- adds the `aria-current="page"` attribute to final breadcrumbs
- makes all final breadcrumbs link to the url of the page, rather than `#`.

**Breadcrumb structure:**
Home(index) > [Supply chain name](task list) > ...

The breadcrumbs of existing pages are now as follows:

- Task list
![Screenshot 2021-04-29 at 17 07 07](https://user-images.githubusercontent.com/22460823/116582491-57f0cd00-a90d-11eb-8715-9918744ea7c1.png)

- Complete page (after submitting update for a supply chain)
![Screenshot 2021-04-29 at 17 10 04](https://user-images.githubusercontent.com/22460823/116582946-c0d84500-a90d-11eb-86ec-9f648de30651.png)

- Strategic action summary page
![Screenshot 2021-04-29 at 17 09 00](https://user-images.githubusercontent.com/22460823/116582781-9ab2a500-a90d-11eb-867d-06928bfddec0.png)


- Supply chain summary page
![Screenshot 2021-04-29 at 17 08 44](https://user-images.githubusercontent.com/22460823/116582742-9090a680-a90d-11eb-8063-a60da6564d7c.png)
