### PR TITLE
Create django admin

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install python packages
         run: pip install -r requirements.txt
       - name: Run unit tests
-        run: which pip && python --version && pytest defend_data_capture --collect-only
+        run: which pip && python --version && pytest defend_data_capture
       - name: Setup node
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -15,8 +15,6 @@ jobs:
           python-version: '3.8.9'
       - name: Install python packages
         run: pip install -r requirements.txt
-      - name: Run unit tests
-        run: which pip && python --version && pytest defend_data_capture
       - name: Setup node
         uses: actions/setup-node@v2
         with:
@@ -25,8 +23,11 @@ jobs:
         run: npm install
       - name: Run webpack
         run: nohup npm run dev &
+      - name: Collect static files
+        run: python defend_data_capture/manage.py collectstatic 
       - name: Bring up db container
         run: docker-compose -f docker-compose.yaml up -d
-
+      - name: Run unit tests
+        run: pytest defend_data_capture
       - name: Run functional tests
         run: bash run_functional_tests.sh

--- a/defend_data_capture/accounts/models.py
+++ b/defend_data_capture/accounts/models.py
@@ -78,6 +78,9 @@ class User(AbstractBaseUser, PermissionsMixin):
     )
     USERNAME_FIELD = "sso_email_user_id"
 
+    def __str__(self):
+        return f"{self.first_name} {self.last_name}"
+
 
 class GovDepartment(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)

--- a/defend_data_capture/defend_data_capture/settings.py
+++ b/defend_data_capture/defend_data_capture/settings.py
@@ -28,11 +28,12 @@ ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["localhost"])
 
 INSTALLED_APPS = [
     "authbroker_client",
-    "django.contrib.admin",
+    "django.contrib.admin.apps.SimpleAdminConfig",
     "django.contrib.auth",
     "django.contrib.contenttypes",
-    "django.contrib.sessions",
     "django.contrib.messages",
+    "django.contrib.postgres",
+    "django.contrib.sessions",
     "django.contrib.staticfiles",
     "supply_chains",
     "accounts",

--- a/defend_data_capture/defend_data_capture/urls.py
+++ b/defend_data_capture/defend_data_capture/urls.py
@@ -1,8 +1,10 @@
+from django.conf import settings
 from django.contrib import admin
 from django.urls import path, include
 from rest_framework import routers
 
 from accounts.api_views import UserViewSet
+from supply_chains.admin import admin_site
 from supply_chains.api_views import (
     StrategicActionViewset,
     StrategicActionUpdateViewset,
@@ -37,7 +39,7 @@ router.register(
 
 urlpatterns = [
     path("auth/", include("authbroker_client.urls")),
-    path("admin/", admin.site.urls),
+    path("admin/", admin_site.urls),
     path("api/", include(router.urls)),
     path("", HomePageView.as_view(), name="index"),
     path("<slug:supply_chain_slug>", SCTaskListView.as_view(), name="tlist"),

--- a/defend_data_capture/supply_chains/admin.py
+++ b/defend_data_capture/supply_chains/admin.py
@@ -1,3 +1,92 @@
+from django import forms
 from django.contrib import admin
+from django.contrib.admin import AdminSite
+from django.contrib.postgres.forms.array import SplitArrayField
+from django.http import HttpResponseRedirect
+from django.urls import reverse
 
-# Register your models here.
+from accounts.models import GovDepartment, User
+from supply_chains.models import SupplyChain, StrategicAction, StrategicActionUpdate
+
+
+class CustomAdminSite(AdminSite):
+    site_header = "Update supply chain information admin"
+
+    def login(self, request, extra_context=None):
+        if request.user.is_authenticated:
+            if request.user.is_staff:
+                index_path = reverse(
+                    "admin:index",
+                    current_app=self.name,
+                )
+                return HttpResponseRedirect(index_path)
+
+        return HttpResponseRedirect(reverse("index"))
+
+
+admin_site = CustomAdminSite(name="admin")
+
+
+class GovDepartmentForm(forms.ModelForm):
+    email_domains = SplitArrayField(
+        base_field=forms.fields.CharField(max_length=255, required=False),
+        remove_trailing_nulls=True,
+        size=5,
+        help_text="An email domain is the section of the email address after the '@' sign. E.g. trade.gov.uk.",
+    )
+
+
+class GovDepartmentAdmin(admin.ModelAdmin):
+    readonly_fields = ("id",)
+    list_display = ("name",)
+    form = GovDepartmentForm
+
+
+class UserAdmin(admin.ModelAdmin):
+    readonly_fields = ("id",)
+    list_display = (
+        "__str__",
+        "gov_department",
+    )
+
+
+class SupplyChainAdmin(admin.ModelAdmin):
+    readonly_fields = (
+        "slug",
+        "id",
+    )
+    list_display = (
+        "name",
+        "gov_department",
+        "last_submission_date",
+    )
+
+
+class StrategicActionAdmin(admin.ModelAdmin):
+    readonly_fields = (
+        "slug",
+        "id",
+    )
+    list_display = (
+        "name",
+        "supply_chain",
+    )
+
+
+class StrategicActionUpdateAdmin(admin.ModelAdmin):
+    readonly_fields = (
+        "slug",
+        "id",
+    )
+    list_display = (
+        "submission_date",
+        "strategic_action",
+        "supply_chain",
+    )
+
+
+admin_site.register(GovDepartment, GovDepartmentAdmin)
+admin_site.register(User, UserAdmin)
+admin_site.register(SupplyChain, SupplyChainAdmin)
+admin_site.register(StrategicAction, StrategicActionAdmin)
+admin_site.register(StrategicActionUpdate, StrategicActionUpdateAdmin)

--- a/defend_data_capture/supply_chains/models.py
+++ b/defend_data_capture/supply_chains/models.py
@@ -189,6 +189,9 @@ class StrategicAction(models.Model):
     def __str__(self):
         return f"SA: {self.name}, {self.supply_chain.gov_department.name}, {self.get_geographic_scope_display()}, SC: {self.supply_chain.name}"
 
+    def __str__(self):
+        return f"{self.name}, {self.supply_chain}"
+
 
 class SAUQuerySet(models.QuerySet):
     def since(self, deadline, *args, **kwargs):
@@ -351,6 +354,9 @@ class StrategicActionUpdate(models.Model):
     @property
     def has_no_timing_information(self):
         return self.has_no_target_completion_date and self.has_no_is_ongoing
+
+    def __str__(self):
+        return f"Update {self.slug} for {self.strategic_action}"
 
 
 class MaturitySelfAssessment(models.Model):

--- a/defend_data_capture/supply_chains/templates/base.html
+++ b/defend_data_capture/supply_chains/templates/base.html
@@ -41,7 +41,7 @@
                         Resilience tool
                     </a>
                     <span class="app-header-span">
-                        <p class="app-header-item">{{ request.user.first_name }} {{ request.user.last_name }} - {{ request.user.gov_department.name }}</p>
+                        <p class="app-header-item">{{ request.user }} - {{ request.user.gov_department.name }}</p>
                     </span>
                 </div>
             </div>

--- a/defend_data_capture/supply_chains/test/test_admin.py
+++ b/defend_data_capture/supply_chains/test/test_admin.py
@@ -1,0 +1,43 @@
+import pytest
+
+from django.test import Client
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+class TestAdminViews:
+    def test_index_redirects_to_login_unauthenticated(self):
+        """Test unauthenticated user is redirected to admin login."""
+        client = Client()
+        expected_redirect_url = reverse("admin:login") + "?next=/admin/"
+        response = client.get(reverse("admin:index"))
+        assert response.status_code == 302
+        assert response.url == expected_redirect_url
+
+    def test_index_redirects_to_login_authenticated(self, logged_in_client):
+        """Test authenticated user is redirected to admin login."""
+        expected_redirect_url = reverse("admin:login") + "?next=/admin/"
+        response = logged_in_client.get(reverse("admin:index"))
+        assert response.status_code == 302
+        assert response.url == expected_redirect_url
+
+    def test_login_unauthenticated(self):
+        """Test unauthenticated user is redirected to index."""
+        client = Client()
+        response = client.get(reverse("admin:login"))
+        assert response.status_code == 302
+        assert response.url == reverse("index")
+
+    def test_login_authenticated_not_staff(self, logged_in_client):
+        """Test authenticated user is redirected to index if not staff."""
+        response = logged_in_client.get(reverse("admin:login"))
+        assert response.status_code == 302
+        assert response.url == reverse("index")
+
+    def test_login_authenticated_and_staff(self, logged_in_client, test_user):
+        """Test authenticated user successfully reaches admin index when staff."""
+        test_user.is_staff = True
+        test_user.save()
+        response = logged_in_client.get(reverse("admin:login"))
+        assert response.status_code == 302
+        assert response.url == reverse("admin:index")


### PR DESCRIPTION
This PR creates a django admin instance for the application.

**Configuring display of objects**
From feedback we had from future admin users on how they identify different objects, I have configured the appropriate values to appear in the list view for each model. Also, in order for the objects to be easily recognisable, I have added `__str__` methods to models which didn't have them.

**Logging into admin**
To avoid the need for admin users to have two sets of login details, I have overridden the `login()` method for the admin site. 

If a user is already authenticated (via SSO) and they are marked as `is_staff=True` they will be able to access the admin index page. If either of these are not true, they will be redirected to the app's index url, where if they're unauthenticated they will be redirected to SSO to login.

**Custom email domains field**
For the `GovDepartment.email_domains` field, as it is an `ArrayField`, I have created a form for this model, which specifies that the field type for email_domains is a [SplitArrayField](https://docs.djangoproject.com/en/3.2/ref/contrib/postgres/forms/#splitarrayfield). This provides a simpler UI for admin users adding new gov departments.

![Screenshot 2021-05-18 at 14 01 36](https://user-images.githubusercontent.com/22460823/118655553-92011080-b7e1-11eb-80f6-7a58d84c1d43.png)

**NB this PR also removes the `--collect-only` flag accidentally left in the GH action to run pytest.