### PR TITLE
Update content and styling

### DIFF
--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -27,7 +27,6 @@ describe('The Home Page', () => {
     cy.lastWorkingDay().then(deadline => {
           cy.get('li').contains( `You need to complete your monthly update for 5 supply chains by ${deadline}`)
       })
-    cy.get('li').contains('You need to complete your monthly update for 5 supply chains by')
     cy.get('li').contains(
       'Select a supply chain to provide your regular monthly update or to update wider details.'
     )

--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -20,10 +20,14 @@ describe('The Home Page', () => {
   })
   it('displays the correct text', () => {
     cy.get('h1').contains(
-      `Update supply chain information`
+      'Update supply chain information'
     )
+    cy.get('p').contains("It's important to keep your departmental action plan records up to date. This is so we can work towards constantly improving the UK's supply chain resilience.")
     cy.get('h2').contains('Complete your monthly update')
-    cy.get('li').contains('You need to complete your monthly update for 5 supply chains')
+    cy.lastWorkingDay().then(deadline => {
+          cy.get('li').contains( `You need to complete your monthly update for 5 supply chains by ${deadline}`)
+      })
+    cy.get('li').contains('You need to complete your monthly update for 5 supply chains by')
     cy.get('li').contains(
       'Select a supply chain to provide your regular monthly update or to update wider details.'
     )

--- a/cypress/integration/task_list_spec.js
+++ b/cypress/integration/task_list_spec.js
@@ -44,17 +44,6 @@ describe('The Supply Chain Tasklist Page', () => {
   it('displays enabled submit button', () => {
     cy.get('button').contains('Submit monthly update')
   })
-  it('links to the strategic action summary page', () => {
-    cy.get('a').contains('View strategic action summary')
-    .should('have.attr', 'href')
-    .and('equal', `/${supplyChain.slug}/strategic-actions/`)
-  })
-  it('links to the supply chain summary page', () => {
-    cy.get('a').contains('View supply chain summary')
-    .should('have.attr', 'href')
-    .and('equal', `/${supplyChain.slug}/summary/`)
-
-  })
 })
 
 const completedSC = supplyChains[1].fields

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -264,7 +264,7 @@ Cypress.Commands.add(
 Cypress.Commands.add(
     'lastWorkingDay',
     () => {
-        cy.exec('python get_last_working_day_this_month.py').then(result => {
+        cy.exec('env PYTHONPATH=defend_data_capture python defend_data_capture/scripts/get_last_working_day_this_month.py').then(result => {
             cy.wrap(result.stdout)
     })
     }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -261,3 +261,11 @@ Cypress.Commands.add(
     }
 )
 
+Cypress.Commands.add(
+    'lastWorkingDay',
+    () => {
+        cy.exec('python get_last_working_day_this_month.py').then(result => {
+            cy.wrap(result.stdout)
+    })
+    }
+)

--- a/defend_data_capture/assets/stylesheets/application.scss
+++ b/defend_data_capture/assets/stylesheets/application.scss
@@ -1,12 +1,8 @@
-@function frontend-font-url($filename) {
-  @return url("~govuk-frontend/govuk/assets/fonts/" + $filename);
-}
-
 @function frontend-image-url($filename) {
   @return url("~govuk-frontend/govuk/assets/images/" + $filename);
 }
 
-$govuk-font-url-function: frontend-font-url;
+$govuk-font-family: "Arial";
 $govuk-image-url-function: frontend-image-url;
 
 @import "~govuk-frontend/govuk/all";

--- a/defend_data_capture/scripts/get_last_working_day_this_month.py
+++ b/defend_data_capture/scripts/get_last_working_day_this_month.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python3
-
-from datetime import date
-
-from defend_data_capture.supply_chains.utils import (
+from supply_chains.utils import (
     get_last_day_of_this_month,
     get_last_working_day_of_a_month,
 )

--- a/defend_data_capture/supply_chains/templates/base.html
+++ b/defend_data_capture/supply_chains/templates/base.html
@@ -23,27 +23,12 @@
     <header role="banner">
         <div class="govuk-header" data-module="govuk-header">
             <div class="govuk-header__container govuk-width-container">
-                <div class="govuk-header__logo">
-                    <a href="#" class="govuk-header__link govuk-header__link--homepage">
-                        <span class="govuk-header__logotype">
-                            <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
-                                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-                                <image src="/assets/images/govuk-logotype-crown.png" xlink:href="data:," display="none" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
-                            </svg>
-                            <span class="govuk-header__logotype-text">
-                                GOV.UK
-                            </span>
-                        </span>
-                    </a>
-                </div>
-                <div class="govuk-header__content">
-                    <a href="/" class="govuk-header__link govuk-header__link--service-name">
-                        Resilience tool
-                    </a>
-                    <span class="app-header-span">
-                        <p class="app-header-item">{{ request.user }} - {{ request.user.gov_department.name }}</p>
-                    </span>
-                </div>
+                <a href="/" class="govuk-header__link govuk-header__link--service-name">
+                    UK supply chain resilience tool
+                </a>
+                <span class="app-header-span">
+                    <p class="app-header-item">{{ request.user }} - {{ request.user.gov_department.name }}</p>
+                </span>
             </div>
         </div>
         <div class="govuk-phase-banner govuk-width-container">
@@ -55,9 +40,6 @@
                     <span class="govuk-phase-banner__text">
                         This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
                     </span>
-                </span>
-                <span class="app-switch-to-tool-link">
-                    <a class="govuk-link govuk-link--no-visited-state" href="#">Switch to tool</a>
                 </span>
             </p>
         </div>

--- a/defend_data_capture/supply_chains/templates/index.html
+++ b/defend_data_capture/supply_chains/templates/index.html
@@ -2,14 +2,9 @@
 
 {% block body %}
     <h1 class="govuk-heading-xl">Update supply chain information</h1>
-
     <p class="govuk-body">
         It's important to keep your departmental action plan records up to date. This is so we can work towards constantly improving the UK's supply chain resilience.
     </p>
-    <div class="govuk-inset-text">
-        Find more information on the data you provide in the <a class="govuk-link" href="#">UK supply chian resilience tool</a>.
-    </div>
-
     <h2 class="govuk-heading-l"> Complete your monthly update</h2>
     <ul class="govuk-list govuk-list--bullet">
         <li>

--- a/defend_data_capture/supply_chains/templates/task_list.html
+++ b/defend_data_capture/supply_chains/templates/task_list.html
@@ -117,35 +117,7 @@
             </button>
         </form>
     {% else %}
-    <br>
-    <br>
+        <a href={% url 'index' %} class="govuk-button govuk-button--secondary">Back to home</a>
     {% endif %}
-
-
-    <h2 class="govuk-heading-l">Strategic action summary</h2>
-    <p class="govuk-body">
-        Make sure you have updated and completed all relevant sections.
-    </p>
-    <p class="govuk-body">
-        This includes: Description of the action, impact, strategic action framework category and depedencies
-    </p>
-    <p class="govuk-body">
-        <a href={% url 'strategic-action-summary' view.supply_chain.slug %} class="govuk-link">View strategic action summary</a>
-    </p>
-
-    <h2 class="govuk-heading-l">Supply chain summary</h2>
-    <p class="govuk-body">
-        Make sure you have updated and completed all relevant sections.
-    </p>
-    <p class="govuk-body">
-        This includes: Key information, vulnerability assessment, scenario assessment, maturity self assessment, risk monitoring and archived strategic actions
-    </p>
-    <p class="govuk-body">
-        <a href={% url 'supply-chain-summary' view.supply_chain.slug %} class="govuk-link">View supply chain summary</a>
-    </p>
-
-    <br>
-    <a href={% url 'index' %} class="govuk-button govuk-button--secondary">Back to home</a>
-
 
 {% endblock %}

--- a/get_last_working_day_this_month.py
+++ b/get_last_working_day_this_month.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+from datetime import date
+
+from defend_data_capture.supply_chains.utils import (
+    get_last_day_of_this_month,
+    get_last_working_day_of_a_month,
+)
+
+
+def get_date_suffix(day):
+    if 4 <= day <= 20 or 24 <= day <= 30:
+        return "th"
+    else:
+        return ["st", "nd", "rd"][day % 10 - 1]
+
+
+def get_formatted_deadline():
+    deadline = get_last_working_day_of_a_month(get_last_day_of_this_month())
+    suffix = get_date_suffix(deadline.day)
+    print(deadline.strftime(f"%A %d{suffix} %B %Y"))
+
+
+if __name__ == "__main__":
+    get_formatted_deadline()


### PR DESCRIPTION
This PR:

- removes references to features not yet ready for release - the data visualisation tool and the supply chain/strategic action summary pages
- updates the font and header in-line with non gov.uk hosted services - removing the GOV UK logo and making the font Arial
- updates the homepage spec to better test the content of the page - the deadline and the description paragraph

Given that the deadline changes dynamically based on the last working day of the current month, I have added a script which calls the util `get_last_working_day_of_a_month`. This is then called within a new custom cypress command.

### Homepage after changes
![image](https://user-images.githubusercontent.com/22460823/118986431-43857a80-b977-11eb-911c-acdc384ae93b.png)

### Task list page after changes
![image](https://user-images.githubusercontent.com/22460823/118986454-4b451f00-b977-11eb-83a9-132a416d2cda.png)
